### PR TITLE
adds `pod` tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `KubernetesCredentials` block for generating authenticated Kubernetes clients - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/19)
 - Tasks for interacting with `job` resources: `create_namespaced_job`, `delete_namespaced_job`, `list_namespaced_job`, `patch_namespaced_job`, `read_namespaced_job`, `replace_namespaced_job` - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/19)
+- Tasks for interacting with `pod` resources: `create_namespaced_pod`, `delete_namespaced_pod`, `list_namespaced_pod`, `patch_namespaced_pod`, `read_namespaced_pod`, `read_namespaced_pod_logs`, `replace_namespaced_pod` - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)
 
 ### Changed
+- `KubernetesCredentials` block to use a single `get_client` method capable of creating all resource-specific client types - [#21](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)
+
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `KubernetesCredentials` block for generating authenticated Kubernetes clients - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/19)
 - Tasks for interacting with `job` resources: `create_namespaced_job`, `delete_namespaced_job`, `list_namespaced_job`, `patch_namespaced_job`, `read_namespaced_job`, `replace_namespaced_job` - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/19)
-- Tasks for interacting with `pod` resources: `create_namespaced_pod`, `delete_namespaced_pod`, `list_namespaced_pod`, `patch_namespaced_pod`, `read_namespaced_pod`, `read_namespaced_pod_logs`, `replace_namespaced_pod` - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)
+- Tasks for interacting with `pod` resources: `create_namespaced_pod`, `delete_namespaced_pod`, `list_namespaced_pod`, `patch_namespaced_pod`, `read_namespaced_pod`, `read_namespaced_pod_logs`, `replace_namespaced_pod` - [#21](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)
 
 ### Changed
 - `KubernetesCredentials` block to use a single `get_client` method capable of creating all resource-specific client types - [#21](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,1 +1,1 @@
-:::prefect_kubernetes.jobs
+::: prefect_kubernetes.jobs

--- a/docs/pods.md
+++ b/docs/pods.md
@@ -1,0 +1,1 @@
+::: prefect_kubernetes.pods

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,3 +39,4 @@ nav:
     - Credentials: credentials.md
     - Exceptions: exceptions.md
     - Jobs: jobs.md
+    - Pods: pods.md

--- a/prefect_kubernetes/credentials.py
+++ b/prefect_kubernetes/credentials.py
@@ -1,13 +1,22 @@
 """Module for defining Kubernetes credential handling and client generation."""
 
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Generator, Optional, Union
 
 from kubernetes import config as kube_config
-from kubernetes.client import ApiClient, AppsV1Api, BatchV1Api, CoreV1Api
+from kubernetes.client import ApiClient, AppsV1Api, BatchV1Api, Configuration, CoreV1Api
 from kubernetes.config.config_exception import ConfigException
 from prefect.blocks.core import Block
 from prefect.blocks.kubernetes import KubernetesClusterConfig
+from prefect.utilities.collections import listrepr
+
+KubernetesClient = Union[AppsV1Api, BatchV1Api, CoreV1Api]
+
+K8S_CLIENT_TYPES = {
+    "apps": AppsV1Api,
+    "batch": BatchV1Api,
+    "core": CoreV1Api,
+}
 
 
 class KubernetesCredentials(Block):
@@ -49,7 +58,7 @@ class KubernetesCredentials(Block):
         @flow
         def kubernetes_orchestrator():
             create_namespaced_job(
-                body=V1Job(**{"Marvin": "42"}),
+                body=V1Job(**{"metadata": {"name": "my-job"}}),
                 kubernetes_credentials=kubernetes_credentials
             )
         ```
@@ -61,46 +70,40 @@ class KubernetesCredentials(Block):
     cluster_config: Optional[KubernetesClusterConfig] = None
 
     @contextmanager
-    def get_app_client(self) -> Generator[AppsV1Api, None, None]:
+    def get_client(
+        self,
+        client_type: str,
+        configuration: Optional[Configuration] = None,
+    ) -> Generator[KubernetesClient, None, None]:
         """Convenience method for retrieving a Kubernetes API client for deployment resources.
 
+        Args:
+            client_type: The resource-specific type of Kubernetes client to retrieve.
+
         Yields:
-            Kubernetes API client to interact with "deployment" resources.
+            An authenticated, resource-specific Kubernetes API client.
+
+        Example:
+            ```python
+            from prefect_kubernetes.credentials import KubernetesCredentials
+
+            with KubernetesCredentials.get_client("core") as core_v1_client:
+                for pod in core_v1_client.list_namespaced_pod():
+                    print(pod.metadata.name)
+            ```
         """
-        with self.get_generic_client() as generic_client:
+        client_config = configuration or Configuration()
+
+        with ApiClient(configuration=client_config) as generic_client:
             try:
-                yield AppsV1Api(api_client=generic_client)
+                yield self.get_resource_specific_client(client_type)
             finally:
                 generic_client.rest_client.pool_manager.clear()
 
-    @contextmanager
-    def get_batch_client(self) -> Generator[BatchV1Api, None, None]:
-        """Convenience method for retrieving a Kubernetes API client for job resources.
-
-        Yields:
-            Kubernetes API client to interact with "job" resources.
-        """
-        with self.get_generic_client() as generic_client:
-            try:
-                yield BatchV1Api(api_client=generic_client)
-            finally:
-                generic_client.rest_client.pool_manager.clear()
-
-    @contextmanager
-    def get_core_client(self) -> Generator[CoreV1Api, None, None]:
-        """Convenience method for retrieving a Kubernetes API client for core resources.
-
-        Yields:
-            Kubernetes API client to interact with "pod", "service"
-            and "secret" resources.
-        """
-        with self.get_generic_client() as generic_client:
-            try:
-                yield CoreV1Api(api_client=generic_client)
-            finally:
-                generic_client.rest_client.pool_manager.clear()
-
-    def get_generic_client(self) -> ApiClient:
+    def get_resource_specific_client(
+        self,
+        client_type: str,
+    ) -> KubernetesClient:
         """
         Utility function for configuring a generic Kubernetes client.
         It will attempt to connect to a Kubernetes cluster in three steps with
@@ -116,6 +119,9 @@ class KubernetesCredentials(Block):
         3. Attempt out-of-cluster connection using the default location for a
         kube config file.
 
+        Args:
+            resource: The Kubernetes resource to configure a client for.
+
         Returns:
             An authenticated, generic Kubernetes Client.
         """
@@ -128,5 +134,10 @@ class KubernetesCredentials(Block):
             except ConfigException:
                 kube_config.load_kube_config()
 
-        client = ApiClient()
-        return client
+        try:
+            return K8S_CLIENT_TYPES[client_type]()
+        except KeyError:
+            raise ValueError(
+                f"Invalid client type provided '{client_type}'."
+                f" Must be one of {listrepr(K8S_CLIENT_TYPES.keys())}."
+            )

--- a/prefect_kubernetes/credentials.py
+++ b/prefect_kubernetes/credentials.py
@@ -1,7 +1,7 @@
 """Module for defining Kubernetes credential handling and client generation."""
 
 from contextlib import contextmanager
-from typing import Generator, Literal, Optional, Union
+from typing import Generator, Optional, Union
 
 from kubernetes import config as kube_config
 from kubernetes.client import ApiClient, AppsV1Api, BatchV1Api, Configuration, CoreV1Api
@@ -9,6 +9,7 @@ from kubernetes.config.config_exception import ConfigException
 from prefect.blocks.core import Block
 from prefect.blocks.kubernetes import KubernetesClusterConfig
 from prefect.utilities.collections import listrepr
+from typing_extensions import Literal
 
 KubernetesClient = Union[AppsV1Api, BatchV1Api, CoreV1Api]
 

--- a/prefect_kubernetes/credentials.py
+++ b/prefect_kubernetes/credentials.py
@@ -1,7 +1,7 @@
 """Module for defining Kubernetes credential handling and client generation."""
 
 from contextlib import contextmanager
-from typing import Generator, Optional, Union
+from typing import Generator, Literal, Optional, Union
 
 from kubernetes import config as kube_config
 from kubernetes.client import ApiClient, AppsV1Api, BatchV1Api, Configuration, CoreV1Api
@@ -78,7 +78,7 @@ class KubernetesCredentials(Block):
     @contextmanager
     def get_client(
         self,
-        client_type: str,
+        client_type: Literal["apps", "batch", "core"],
         configuration: Optional[Configuration] = None,
     ) -> Generator[KubernetesClient, None, None]:
         """Convenience method for retrieving a Kubernetes API client for deployment resources.

--- a/prefect_kubernetes/jobs.py
+++ b/prefect_kubernetes/jobs.py
@@ -157,7 +157,7 @@ async def patch_namespaced_job(
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Job:
-    """Task for deleting a namespaced Kubernetes job.
+    """Task for patching a namespaced Kubernetes job.
 
     Args:
         kubernetes_credentials: KubernetesCredentials block

--- a/prefect_kubernetes/jobs.py
+++ b/prefect_kubernetes/jobs.py
@@ -58,7 +58,7 @@ async def delete_namespaced_job(
     kubernetes_credentials: KubernetesCredentials,
     namespace: Optional[str] = "default",
     kube_kwargs: Optional[Dict[str, Any]] = None,
-    delete_option_kwargs: Optional[Dict] = None,
+    delete_option_kwargs: Optional[Dict[str, Any]] = None,
 ) -> V1Status:
     """Task for deleting a namespaced Kubernetes job.
 

--- a/prefect_kubernetes/jobs.py
+++ b/prefect_kubernetes/jobs.py
@@ -45,10 +45,10 @@ async def create_namespaced_job(
             )
         ```
     """
-    with kubernetes_credentials.get_batch_client() as api_client:
+    with kubernetes_credentials.get_client("batch") as batch_v1_client:
 
         return await run_sync_in_worker_thread(
-            api_client.create_namespaced_job,
+            batch_v1_client.create_namespaced_job,
             namespace=namespace,
             body=body,
             **kube_kwargs,
@@ -96,10 +96,10 @@ async def delete_namespaced_job(
         ```
     """
 
-    with kubernetes_credentials.get_batch_client() as api_client:
+    with kubernetes_credentials.get_client("batch") as batch_v1_client:
 
         return await run_sync_in_worker_thread(
-            api_client.delete_namespaced_job,
+            batch_v1_client.delete_namespaced_job,
             name=job_name,
             body=body,
             namespace=namespace,
@@ -140,10 +140,10 @@ async def list_namespaced_job(
             )
         ```
     """
-    with kubernetes_credentials.get_batch_client() as api_client:
+    with kubernetes_credentials.get_client("batch") as batch_v1_client:
 
         return await run_sync_in_worker_thread(
-            api_client.list_namespaced_job,
+            batch_v1_client.list_namespaced_job,
             namespace=namespace,
             **kube_kwargs,
         )
@@ -193,10 +193,10 @@ async def patch_namespaced_job(
         ```
     """
 
-    with kubernetes_credentials.get_batch_client() as api_client:
+    with kubernetes_credentials.get_client("batch") as batch_v1_client:
 
         return await run_sync_in_worker_thread(
-            api_client.patch_namespaced_job,
+            batch_v1_client.patch_namespaced_job,
             name=job_name,
             namespace=namespace,
             body=body,
@@ -242,10 +242,10 @@ async def read_namespaced_job(
             )
         ```
     """
-    with kubernetes_credentials.get_batch_client() as api_client:
+    with kubernetes_credentials.get_client("batch") as batch_v1_client:
 
         return await run_sync_in_worker_thread(
-            api_client.read_namespaced_job,
+            batch_v1_client.read_namespaced_job,
             name=job_name,
             namespace=namespace,
             **kube_kwargs,
@@ -290,10 +290,10 @@ async def replace_namespaced_job(
             )
         ```
     """
-    with kubernetes_credentials.get_batch_client() as api_client:
+    with kubernetes_credentials.get_client("batch") as batch_v1_client:
 
         return await run_sync_in_worker_thread(
-            api_client.replace_namespaced_job,
+            batch_v1_client.replace_namespaced_job,
             name=job_name,
             body=body,
             namespace=namespace,

--- a/prefect_kubernetes/jobs.py
+++ b/prefect_kubernetes/jobs.py
@@ -12,7 +12,7 @@ from prefect_kubernetes.credentials import KubernetesCredentials
 @task
 async def create_namespaced_job(
     kubernetes_credentials: KubernetesCredentials,
-    body: V1Job,
+    new_job: V1Job,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Job:
@@ -21,7 +21,7 @@ async def create_namespaced_job(
     Args:
         kubernetes_credentials: `KubernetesCredentials` block
             holding authentication needed to generate the required API client.
-        body: A Kubernetes `V1Job` specification.
+        new_job: A Kubernetes `V1Job` specification.
         namespace: The Kubernetes namespace to create this job in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
@@ -40,7 +40,7 @@ async def create_namespaced_job(
         @flow
         def kubernetes_orchestrator():
             v1_job_metadata = create_namespaced_job(
-                body=V1Job(**{"metadata": {"name": "test-job"}}),
+                new_job=V1Job(metadata={"labels": {"foo": "bar"}}),
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
             )
         ```
@@ -50,7 +50,7 @@ async def create_namespaced_job(
         return await run_sync_in_worker_thread(
             batch_v1_client.create_namespaced_job,
             namespace=namespace,
-            body=body,
+            body=new_job,
             **kube_kwargs,
         )
 
@@ -59,7 +59,7 @@ async def create_namespaced_job(
 async def delete_namespaced_job(
     kubernetes_credentials: KubernetesCredentials,
     job_name: str,
-    body: Optional[V1DeleteOptions] = None,
+    delete_options: Optional[V1DeleteOptions] = None,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Status:
@@ -69,7 +69,7 @@ async def delete_namespaced_job(
         kubernetes_credentials: `KubernetesCredentials` block
             holding authentication needed to generate the required API client.
         job_name: The name of a job to delete.
-        body: A Kubernetes `V1DeleteOptions` object.
+        delete_options: A Kubernetes `V1DeleteOptions` object.
         namespace: The Kubernetes namespace to delete this job in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
@@ -91,7 +91,7 @@ async def delete_namespaced_job(
             v1_job_status = delete_namespaced_job(
                 job_name="my-job",
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
-                body=V1DeleteOptions(propagation_policy="Foreground"),
+                delete_options=V1DeleteOptions(propagation_policy="Foreground"),
             )
         ```
     """
@@ -101,7 +101,7 @@ async def delete_namespaced_job(
         return await run_sync_in_worker_thread(
             batch_v1_client.delete_namespaced_job,
             name=job_name,
-            body=body,
+            body=delete_options,
             namespace=namespace,
             **kube_kwargs,
         )
@@ -153,7 +153,7 @@ async def list_namespaced_job(
 async def patch_namespaced_job(
     kubernetes_credentials: KubernetesCredentials,
     job_name: str,
-    body: V1Job,
+    job_updates: V1Job,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Job:
@@ -163,7 +163,7 @@ async def patch_namespaced_job(
         kubernetes_credentials: KubernetesCredentials block
             holding authentication needed to generate the required API client.
         job_name: The name of a job to patch.
-        body: A Kubernetes `V1Job` specification.
+        job_updates: A Kubernetes `V1Job` specification.
         namespace: The Kubernetes namespace to patch this job in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
@@ -187,7 +187,7 @@ async def patch_namespaced_job(
         def kubernetes_orchestrator():
             v1_job_metadata = patch_namespaced_job(
                 job_name="my-job",
-                body=V1Job(**{"metadata": {"labels": {"foo": "bar"}}}),
+                job_updates=V1Job(metadata={"labels": {"foo": "bar"}}}),
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
             )
         ```
@@ -199,7 +199,7 @@ async def patch_namespaced_job(
             batch_v1_client.patch_namespaced_job,
             name=job_name,
             namespace=namespace,
-            body=body,
+            body=job_updates,
             **kube_kwargs,
         )
 
@@ -256,7 +256,7 @@ async def read_namespaced_job(
 async def replace_namespaced_job(
     kubernetes_credentials: KubernetesCredentials,
     job_name: str,
-    body: V1Job,
+    new_job: V1Job,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Job:
@@ -266,7 +266,7 @@ async def replace_namespaced_job(
         kubernetes_credentials: `KubernetesCredentials` block
             holding authentication needed to generate the required API client.
         job_name: The name of a job to replace.
-        body: A Kubernetes `V1Job` specification.
+        new_job: A Kubernetes `V1Job` specification.
         namespace: The Kubernetes namespace to replace this job in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
@@ -284,7 +284,7 @@ async def replace_namespaced_job(
         @flow
         def kubernetes_orchestrator():
             v1_job_metadata = replace_namespaced_job(
-                body={"metadata": {"labels": {"foo": "bar"}}},
+                new_job=V1Job(metadata={"labels": {"foo": "bar"}}),
                 job_name="my-job",
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
             )
@@ -295,7 +295,7 @@ async def replace_namespaced_job(
         return await run_sync_in_worker_thread(
             batch_v1_client.replace_namespaced_job,
             name=job_name,
-            body=body,
+            body=new_job,
             namespace=namespace,
             **kube_kwargs,
         )

--- a/prefect_kubernetes/pods.py
+++ b/prefect_kubernetes/pods.py
@@ -1,5 +1,4 @@
 """Module for interacting with Kubernetes pods from Prefect flows."""
-
 from typing import Any, Callable, Dict, Optional, Union
 
 from kubernetes.client.exceptions import ApiException
@@ -14,7 +13,7 @@ from prefect_kubernetes.credentials import KubernetesCredentials
 @task
 async def create_namespaced_pod(
     kubernetes_credentials: KubernetesCredentials,
-    body: V1Pod,
+    new_pod: V1Pod,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Pod:
@@ -23,7 +22,7 @@ async def create_namespaced_pod(
     Args:
         kubernetes_credentials: `KubernetesCredentials` block for creating
             authenticated Kubernetes API clients.
-        body: A Kubernetes `V1Pod` specification.
+        new_pod: A Kubernetes `V1Pod` specification.
         namespace: The Kubernetes namespace to create this pod in.
         **kube_kwargs: Optional extra keyword arguments to pass to the Kubernetes API.
 
@@ -42,7 +41,7 @@ async def create_namespaced_pod(
         def kubernetes_orchestrator():
             v1_pod_metadata = create_namespaced_pod(
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
-                body=V1Pod(**{"metadata": {"name": "test-pod"}}),
+                new_pod=V1Pod(metadata={"name": "test-pod"}),
             )
         ```
     """
@@ -51,7 +50,7 @@ async def create_namespaced_pod(
         return await run_sync_in_worker_thread(
             core_v1_client.create_namespaced_pod,
             namespace=namespace,
-            body=body,
+            body=new_pod,
             **kube_kwargs,
         )
 
@@ -60,7 +59,7 @@ async def create_namespaced_pod(
 async def delete_namespaced_pod(
     kubernetes_credentials: KubernetesCredentials,
     pod_name: str,
-    body: Optional[V1DeleteOptions] = None,
+    delete_options: Optional[V1DeleteOptions] = None,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Pod:
@@ -70,7 +69,7 @@ async def delete_namespaced_pod(
         kubernetes_credentials: `KubernetesCredentials` block for creating
             authenticated Kubernetes API clients.
         pod_name: The name of the pod to delete.
-        body: A Kubernetes `V1DeleteOptions` object.
+        delete_options: A Kubernetes `V1DeleteOptions` object.
         namespace: The Kubernetes namespace to delete this pod from.
         **kube_kwargs: Optional extra keyword arguments to pass to the Kubernetes API.
 
@@ -90,7 +89,7 @@ async def delete_namespaced_pod(
             v1_pod_metadata = delete_namespaced_pod(
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
                 pod_name="test-pod",
-                body=V1DeleteOptions(grace_period_seconds=0),
+                delete_options=V1DeleteOptions(grace_period_seconds=0),
             )
         ```
     """
@@ -99,7 +98,7 @@ async def delete_namespaced_pod(
         return await run_sync_in_worker_thread(
             core_v1_client.delete_namespaced_pod,
             pod_name,
-            body=body,
+            body=delete_options,
             namespace=namespace,
             **kube_kwargs,
         )
@@ -147,7 +146,7 @@ async def list_namespaced_pod(
 async def patch_namespaced_pod(
     kubernetes_credentials: KubernetesCredentials,
     pod_name: str,
-    body: V1Pod,
+    pod_updates: V1Pod,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Pod:
@@ -157,7 +156,7 @@ async def patch_namespaced_pod(
         kubernetes_credentials: `KubernetesCredentials` block for creating
             authenticated Kubernetes API clients.
         pod_name: The name of the pod to patch.
-        body: A Kubernetes `V1Pod` object.
+        pod_updates: A Kubernetes `V1Pod` object.
         namespace: The Kubernetes namespace to patch this pod in.
         **kube_kwargs: Optional extra keyword arguments to pass to the Kubernetes API.
 
@@ -177,7 +176,7 @@ async def patch_namespaced_pod(
             v1_pod_metadata = patch_namespaced_pod(
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
                 pod_name="test-pod",
-                body=V1Pod(**{"metadata": {"labels": {"foo": "bar"}}}),
+                pod_updates=V1Pod(metadata={"labels": {"foo": "bar"}}),
             )
         ```
     """
@@ -187,7 +186,7 @@ async def patch_namespaced_pod(
             core_v1_client.patch_namespaced_pod,
             name=pod_name,
             namespace=namespace,
-            body=body,
+            body=pod_updates,
             **kube_kwargs,
         )
 
@@ -316,7 +315,7 @@ async def read_namespaced_pod_logs(
 async def replace_namespaced_pod(
     kubernetes_credentials: KubernetesCredentials,
     pod_name: str,
-    body: V1Pod,
+    new_pod: V1Pod,
     namespace: Optional[str] = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> V1Pod:
@@ -326,7 +325,7 @@ async def replace_namespaced_pod(
         kubernetes_credentials: `KubernetesCredentials` block for creating
             authenticated Kubernetes API clients.
         pod_name: The name of the pod to replace.
-        body: A Kubernetes `V1Pod` object.
+        new_pod: A Kubernetes `V1Pod` object.
         namespace: The Kubernetes namespace to replace this pod in.
         **kube_kwargs: Optional extra keyword arguments to pass to the Kubernetes API.
 
@@ -346,7 +345,7 @@ async def replace_namespaced_pod(
             v1_pod_metadata = replace_namespaced_pod(
                 kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
                 pod_name="test-pod",
-                body=V1Pod(**{"metadata": {"labels": {"foo": "bar"}}})
+                new_pod=V1Pod(metadata={"labels": {"foo": "bar"}})
             )
         ```
     """
@@ -354,7 +353,7 @@ async def replace_namespaced_pod(
 
         return await run_sync_in_worker_thread(
             core_v1_client.replace_namespaced_pod,
-            body=body,
+            body=new_pod,
             name=pod_name,
             namespace=namespace,
             **kube_kwargs,

--- a/prefect_kubernetes/pods.py
+++ b/prefect_kubernetes/pods.py
@@ -1,0 +1,131 @@
+"""Module for interacting with Kubernetes pods from Prefect flows."""
+from typing import Any, Dict, Optional
+
+from kubernetes.client.models import V1Pod, V1PodList
+from prefect import task
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
+
+from prefect_kubernetes.credentials import KubernetesCredentials
+
+
+@task
+async def create_namespaced_pod(
+    body: Dict,
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+    kube_kwargs: Optional[Dict[str, Any]] = None,
+) -> V1Pod:
+    """Create a Kubernetes pod in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    return await run_sync_in_worker_thread(
+        client.create_namespaced_pod, namespace=namespace, body=body, **kube_kwargs
+    )
+
+
+@task
+async def delete_namespaced_pod(
+    pod_name: str,
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+    kube_kwargs: Optional[Dict[str, Any]] = None,
+    delete_option_kwargs: Optional[Dict[str, Any]] = None,
+) -> V1Pod:
+    """Delete a Kubernetes pod in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    kube_kwargs = kube_kwargs or {}
+
+    if delete_option_kwargs:
+        kube_kwargs.update(body=client.V1DeleteOptions(**delete_option_kwargs))
+
+    return await run_sync_in_worker_thread(
+        client.delete_namespaced_pod, pod_name, namespace=namespace, **kube_kwargs
+    )
+
+
+@task
+async def list_namespaced_pod(
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+    kube_kwargs: Optional[Dict[str, Any]] = None,
+) -> V1PodList:
+    """List all pods in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    return await run_sync_in_worker_thread(
+        client.list_namespaced_pod, namespace=namespace, **kube_kwargs
+    )
+
+
+@task
+async def patch_namespaced_pod(
+    pod_name: str,
+    body: Dict,
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+    kube_kwargs: Optional[Dict[str, Any]] = None,
+) -> V1Pod:
+    """Patch a Kubernetes pod in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    return await run_sync_in_worker_thread(
+        client.patch_namespaced_pod,
+        name=pod_name,
+        namespace=namespace,
+        body=body,
+        **kube_kwargs
+    )
+
+
+@task
+async def read_namespaced_pod(
+    pod_name: str,
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+    kube_kwargs: Optional[Dict[str, Any]] = None,
+) -> V1Pod:
+    """Read information on a Kubernetes pod in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    return await run_sync_in_worker_thread(
+        client.read_namespaced_pod, name=pod_name, namespace=namespace, **kube_kwargs
+    )
+
+
+@task
+async def read_namespaced_pod_logs(
+    pod_name: str,
+    container: str,
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+) -> str:
+    """Read logs from a Kubernetes pod in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    return await run_sync_in_worker_thread(
+        client.read_namespaced_pod_log,
+        name=pod_name,
+        namespace=namespace,
+        container=container,
+    )
+
+
+@task
+async def replace_namespaced_pod(
+    pod_name: str,
+    body: Dict,
+    kubernetes_credentials: KubernetesCredentials,
+    namespace: Optional[str] = "default",
+    kube_kwargs: Optional[Dict[str, Any]] = None,
+) -> V1Pod:
+    """Replace a Kubernetes pod in a given namespace."""
+    client = kubernetes_credentials.get_core_client()
+
+    return await run_sync_in_worker_thread(
+        client.replace_namespaced_pod,
+        body=body,
+        name=pod_name,
+        namespace=namespace,
+        **kube_kwargs
+    )

--- a/prefect_kubernetes/pods.py
+++ b/prefect_kubernetes/pods.py
@@ -1,4 +1,5 @@
 """Module for interacting with Kubernetes pods from Prefect flows."""
+
 from typing import Any, Callable, Dict, Optional, Union
 
 from kubernetes.client.exceptions import ApiException
@@ -289,22 +290,20 @@ async def read_namespaced_pod_logs(
                 **kube_kwargs,
             )
 
-        # From the kubernetes.watch documentation:
+        # From the `kubernetes.watch` documentation:
         # Note that watching an API resource can expire. The method tries to
         # resume automatically once from the last result, but if that last result
         # is too old as well, an `ApiException` exception will be thrown with
         # ``code`` 410.
 
-        read_logs_coroutine = run_sync_in_worker_thread(
-            core_v1_client.read_namespaced_pod_log,
-            name=pod_name,
-            namespace=namespace,
-            container=container,
-        )
-
         while True:
             try:
-                for log_line in Watch().stream(await read_logs_coroutine):
+                for log_line in Watch().stream(
+                    core_v1_client.read_namespaced_pod_log,
+                    name=pod_name,
+                    namespace=namespace,
+                    container=container,
+                ):
                     print_func(log_line)
                 return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 import yaml
 from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api
+from kubernetes.client.exceptions import ApiException
 from prefect.blocks.kubernetes import KubernetesClusterConfig
 
 from prefect_kubernetes.credentials import KubernetesCredentials
@@ -82,3 +83,12 @@ def _mock_api_core_client(monkeypatch):
     )
 
     return core_client
+
+
+@pytest.fixture
+def mock_stream_timeout(monkeypatch):
+
+    monkeypatch.setattr(
+        "kubernetes.watch.Watch.stream",
+        MagicMock(side_effect=ApiException(status=408)),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,12 +41,12 @@ def _mock_api_app_client(monkeypatch):
     app_client = MagicMock(spec=AppsV1Api)
 
     @contextmanager
-    def get_app_client(_):
+    def get_client(self, _):
         yield app_client
 
     monkeypatch.setattr(
-        "prefect_kubernetes.credentials.KubernetesCredentials.get_app_client",
-        get_app_client,
+        "prefect_kubernetes.credentials.KubernetesCredentials.get_client",
+        get_client,
     )
 
     return app_client
@@ -57,12 +57,12 @@ def _mock_api_batch_client(monkeypatch):
     batch_client = MagicMock(spec=BatchV1Api)
 
     @contextmanager
-    def get_batch_client(_):
+    def get_client(self, _):
         yield batch_client
 
     monkeypatch.setattr(
-        "prefect_kubernetes.credentials.KubernetesCredentials.get_batch_client",
-        get_batch_client,
+        "prefect_kubernetes.credentials.KubernetesCredentials.get_client",
+        get_client,
     )
 
     return batch_client
@@ -73,12 +73,12 @@ def _mock_api_core_client(monkeypatch):
     core_client = MagicMock(spec=CoreV1Api)
 
     @contextmanager
-    def get_core_client(_):
+    def get_client(self, _):
         yield core_client
 
     monkeypatch.setattr(
-        "prefect_kubernetes.credentials.KubernetesCredentials.get_core_client",
-        get_core_client,
+        "prefect_kubernetes.credentials.KubernetesCredentials.get_client",
+        get_client,
     )
 
     return core_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,3 +92,12 @@ def mock_stream_timeout(monkeypatch):
         "kubernetes.watch.Watch.stream",
         MagicMock(side_effect=ApiException(status=408)),
     )
+
+
+@pytest.fixture
+def mock_pod_log(monkeypatch):
+
+    monkeypatch.setattr(
+        "kubernetes.watch.Watch.stream",
+        MagicMock(return_value=["test log"]),
+    )

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -17,6 +17,8 @@ def test_client_return_type(kubernetes_credentials, resource_type, client_type):
 
 
 def test_client_bad_resource_type(kubernetes_credentials):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Invalid client type provided 'shoo-ba-daba-doo'"
+    ):
         with kubernetes_credentials.get_client("shoo-ba-daba-doo"):
             pass

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3,15 +3,20 @@ from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api
 
 
 @pytest.mark.parametrize(
-    "resource_type_method,client_type",
+    "resource_type,client_type",
     [
-        ("get_app_client", AppsV1Api),
-        ("get_batch_client", BatchV1Api),
-        ("get_core_client", CoreV1Api),
+        ("apps", AppsV1Api),
+        ("batch", BatchV1Api),
+        ("core", CoreV1Api),
     ],
 )
-def test_client_return_type(kubernetes_credentials, resource_type_method, client_type):
-    resource_specific_client = getattr(kubernetes_credentials, resource_type_method)
+def test_client_return_type(kubernetes_credentials, resource_type, client_type):
 
-    with resource_specific_client() as client:
+    with kubernetes_credentials.get_client(resource_type) as client:
         assert isinstance(client, client_type)
+
+
+def test_client_bad_resource_type(kubernetes_credentials):
+    with pytest.raises(ValueError):
+        with kubernetes_credentials.get_client("shoo-ba-daba-doo"):
+            pass

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,5 +1,6 @@
 import pytest
 from kubernetes.client.exceptions import ApiValueError
+from kubernetes.client.models import V1Job
 
 from prefect_kubernetes.jobs import (
     create_namespaced_job,
@@ -11,7 +12,7 @@ from prefect_kubernetes.jobs import (
 )
 
 
-async def test_invalid_body_raises_error(kubernetes_credentials):
+async def test_null_body_raises_error(kubernetes_credentials):
     with pytest.raises(ApiValueError):
         await create_namespaced_job.fn(
             body=None, kubernetes_credentials=kubernetes_credentials
@@ -20,29 +21,33 @@ async def test_invalid_body_raises_error(kubernetes_credentials):
         await patch_namespaced_job.fn(
             body=None, job_name="", kubernetes_credentials=kubernetes_credentials
         )
+    with pytest.raises(ApiValueError):
+        await replace_namespaced_job.fn(
+            body=None, job_name="", kubernetes_credentials=kubernetes_credentials
+        )
 
 
 async def test_create_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await create_namespaced_job.fn(
-        body={"test": "a"},
+        body=V1Job(**{"metadata": {"name": "test-job"}}),
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
 
-    assert _mock_api_batch_client.create_namespaced_job.call_args[1]["body"] == {
-        "test": "a"
-    }
+    assert _mock_api_batch_client.create_namespaced_job.call_args[1][
+        "body"
+    ].metadata == {"name": "test-job"}
     assert _mock_api_batch_client.create_namespaced_job.call_args[1]["a"] == "test"
 
 
 async def test_delete_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await delete_namespaced_job.fn(
-        job_name="test_job",
+        job_name="test-job",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
     assert (
-        _mock_api_batch_client.delete_namespaced_job.call_args[1]["name"] == "test_job"
+        _mock_api_batch_client.delete_namespaced_job.call_args[1]["name"] == "test-job"
     )
     assert _mock_api_batch_client.delete_namespaced_job.call_args[1]["a"] == "test"
 
@@ -59,47 +64,47 @@ async def test_list_namespaced_job(kubernetes_credentials, _mock_api_batch_clien
 
 async def test_patch_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await patch_namespaced_job.fn(
-        body={"test": "a"},
-        job_name="test_job",
+        body=V1Job(**{"metadata": {"name": "test-job"}}),
+        job_name="test-job",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
-    assert _mock_api_batch_client.patch_namespaced_job.call_args[1]["body"] == {
-        "test": "a"
-    }
+    assert _mock_api_batch_client.patch_namespaced_job.call_args[1][
+        "body"
+    ].metadata == {"name": "test-job"}
     assert (
-        _mock_api_batch_client.patch_namespaced_job.call_args[1]["name"] == "test_job"
+        _mock_api_batch_client.patch_namespaced_job.call_args[1]["name"] == "test-job"
     )
     assert _mock_api_batch_client.patch_namespaced_job.call_args[1]["a"] == "test"
 
 
 async def test_read_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await read_namespaced_job.fn(
-        job_name="test_job",
+        job_name="test-job",
         namespace="ns",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
-    assert _mock_api_batch_client.read_namespaced_job.call_args[1]["name"] == "test_job"
+    assert _mock_api_batch_client.read_namespaced_job.call_args[1]["name"] == "test-job"
     assert _mock_api_batch_client.read_namespaced_job.call_args[1]["namespace"] == "ns"
     assert _mock_api_batch_client.read_namespaced_job.call_args[1]["a"] == "test"
 
 
 async def test_replace_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await replace_namespaced_job.fn(
-        job_name="test_job",
-        body={"test": "a"},
+        job_name="test-job",
+        body=V1Job(**{"metadata": {"name": "test-job"}}),
         namespace="ns",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
     assert (
-        _mock_api_batch_client.replace_namespaced_job.call_args[1]["name"] == "test_job"
+        _mock_api_batch_client.replace_namespaced_job.call_args[1]["name"] == "test-job"
     )
     assert (
         _mock_api_batch_client.replace_namespaced_job.call_args[1]["namespace"] == "ns"
     )
-    assert _mock_api_batch_client.replace_namespaced_job.call_args[1]["body"] == {
-        "test": "a"
-    }
+    assert _mock_api_batch_client.replace_namespaced_job.call_args[1][
+        "body"
+    ].metadata == {"name": "test-job"}
     assert _mock_api_batch_client.replace_namespaced_job.call_args[1]["a"] == "test"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -15,21 +15,21 @@ from prefect_kubernetes.jobs import (
 async def test_null_body_raises_error(kubernetes_credentials):
     with pytest.raises(ApiValueError):
         await create_namespaced_job.fn(
-            body=None, kubernetes_credentials=kubernetes_credentials
+            new_job=None, kubernetes_credentials=kubernetes_credentials
         )
     with pytest.raises(ApiValueError):
         await patch_namespaced_job.fn(
-            body=None, job_name="", kubernetes_credentials=kubernetes_credentials
+            job_updates=None, job_name="", kubernetes_credentials=kubernetes_credentials
         )
     with pytest.raises(ApiValueError):
         await replace_namespaced_job.fn(
-            body=None, job_name="", kubernetes_credentials=kubernetes_credentials
+            new_job=None, job_name="", kubernetes_credentials=kubernetes_credentials
         )
 
 
 async def test_create_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await create_namespaced_job.fn(
-        body=V1Job(**{"metadata": {"name": "test-job"}}),
+        new_job=V1Job(metadata={"name": "test-job"}),
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
@@ -64,7 +64,7 @@ async def test_list_namespaced_job(kubernetes_credentials, _mock_api_batch_clien
 
 async def test_patch_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await patch_namespaced_job.fn(
-        body=V1Job(**{"metadata": {"name": "test-job"}}),
+        job_updates=V1Job(metadata={"name": "test-job"}),
         job_name="test-job",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
@@ -93,7 +93,7 @@ async def test_read_namespaced_job(kubernetes_credentials, _mock_api_batch_clien
 async def test_replace_namespaced_job(kubernetes_credentials, _mock_api_batch_client):
     await replace_namespaced_job.fn(
         job_name="test-job",
-        body=V1Job(**{"metadata": {"name": "test-job"}}),
+        new_job=V1Job(metadata={"name": "test-job"}),
         namespace="ns",
         a="test",
         kubernetes_credentials=kubernetes_credentials,

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -160,7 +160,7 @@ async def test_bad_v1_pod_kwargs(kubernetes_credentials, task_accepting_pod, pod
 
 
 async def test_read_pod_log_custom_print_func(
-    kubernetes_credentials, _mock_api_core_client
+    kubernetes_credentials, _mock_api_core_client, mock_pod_log, capsys
 ):
     s = await read_namespaced_pod_log.fn(
         kubernetes_credentials=kubernetes_credentials,
@@ -172,16 +172,7 @@ async def test_read_pod_log_custom_print_func(
 
     assert not s
 
-    assert (
-        _mock_api_core_client.read_namespaced_pod_log.call_args[1]["name"] == "test_pod"
-    )
-    assert (
-        _mock_api_core_client.read_namespaced_pod_log.call_args[1]["container"]
-        == "test_container"
-    )
-    assert (
-        _mock_api_core_client.read_namespaced_pod_log.call_args[1]["namespace"] == "ns"
-    )
+    assert capsys.readouterr().out == "test log\n"
 
 
 async def test_read_pod_log_custom_print_func_timeout(

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -1,4 +1,5 @@
 import pytest
+from kubernetes.client.exceptions import ApiValueError
 
 from prefect_kubernetes.pods import (
     create_namespaced_pod,
@@ -11,5 +12,115 @@ from prefect_kubernetes.pods import (
 )
 
 
-async def test_create_namespaced_pod(_mock_api_core_client, kubernetes_credentials):
-    await create_namespaced_pod.fn()
+async def test_invalid_body_raises_error(kubernetes_credentials):
+    with pytest.raises(ApiValueError):
+        await create_namespaced_pod.fn(
+            body=None, kubernetes_credentials=kubernetes_credentials
+        )
+    with pytest.raises(ApiValueError):
+        await patch_namespaced_pod.fn(
+            body=None, pod_name="", kubernetes_credentials=kubernetes_credentials
+        )
+
+
+async def test_create_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
+    await create_namespaced_pod.fn(
+        body={"test": "a"},
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert _mock_api_core_client.create_namespaced_pod.call_args[1]["body"] == {
+        "test": "a"
+    }
+    assert _mock_api_core_client.create_namespaced_pod.call_args[1]["a"] == "test"
+
+
+async def test_delete_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
+    await delete_namespaced_pod.fn(
+        pod_name="test_pod",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert (
+        _mock_api_core_client.delete_namespaced_pod.call_args[1]["namespace"]
+        == "default"
+    )
+    assert _mock_api_core_client.delete_namespaced_pod.call_args[1]["a"] == "test"
+
+
+async def test_list_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
+    await list_namespaced_pod.fn(
+        namespace="ns",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert _mock_api_core_client.list_namespaced_pod.call_args[1]["namespace"] == "ns"
+    assert _mock_api_core_client.list_namespaced_pod.call_args[1]["a"] == "test"
+
+
+async def test_patch_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
+    await patch_namespaced_pod.fn(
+        body={"test": "a"},
+        pod_name="test_pod",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["body"] == {
+        "test": "a"
+    }
+    assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["name"] == "test_pod"
+    assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["a"] == "test"
+
+
+async def test_read_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
+    await read_namespaced_pod.fn(
+        pod_name="test_pod",
+        namespace="ns",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert _mock_api_core_client.read_namespaced_pod.call_args[1]["name"] == "test_pod"
+    assert _mock_api_core_client.read_namespaced_pod.call_args[1]["namespace"] == "ns"
+    assert _mock_api_core_client.read_namespaced_pod.call_args[1]["a"] == "test"
+
+
+async def test_read_namespaced_pod_logs(kubernetes_credentials, _mock_api_core_client):
+    await read_namespaced_pod_logs.fn(
+        pod_name="test_pod",
+        container="test_container",
+        namespace="ns",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert (
+        _mock_api_core_client.read_namespaced_pod_log.call_args[1]["name"] == "test_pod"
+    )
+    assert (
+        _mock_api_core_client.read_namespaced_pod_log.call_args[1]["namespace"] == "ns"
+    )
+    assert (
+        _mock_api_core_client.read_namespaced_pod_log.call_args[1]["container"]
+        == "test_container"
+    )
+    assert _mock_api_core_client.read_namespaced_pod_log.call_args[1]["a"] == "test"
+
+
+async def test_replace_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
+    await replace_namespaced_pod.fn(
+        pod_name="test_pod",
+        body={"test": "a"},
+        namespace="ns",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert (
+        _mock_api_core_client.replace_namespaced_pod.call_args[1]["name"] == "test_pod"
+    )
+    assert (
+        _mock_api_core_client.replace_namespaced_pod.call_args[1]["namespace"] == "ns"
+    )
+    assert _mock_api_core_client.replace_namespaced_pod.call_args[1]["body"] == {
+        "test": "a"
+    }
+    assert _mock_api_core_client.replace_namespaced_pod.call_args[1]["a"] == "test"

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -1,5 +1,5 @@
 import pytest
-from kubernetes.client.exceptions import ApiValueError
+from kubernetes.client.exceptions import ApiException, ApiValueError
 from kubernetes.client.models import V1DeleteOptions, V1Pod
 
 from prefect_kubernetes.pods import (
@@ -152,4 +152,17 @@ async def test_bad_v1_pod_kwargs(kubernetes_credentials, task_accepting_pod):
         await task_accepting_pod.fn(
             body=V1Pod(**{"random_not_real": "shabba-ranks"}),
             kubernetes_credentials=kubernetes_credentials,
+        )
+
+
+async def test_read_pod_logs_custom_print_func_timeout(
+    kubernetes_credentials, mock_stream_timeout
+):
+    with pytest.raises(ApiException):
+        await read_namespaced_pod_logs.fn(
+            kubernetes_credentials=kubernetes_credentials,
+            pod_name="test_pod",
+            container="test_container",
+            namespace="ns",
+            print_func=print,
         )

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -1,5 +1,6 @@
 import pytest
 from kubernetes.client.exceptions import ApiValueError
+from kubernetes.client.models import V1DeleteOptions, V1Pod
 
 from prefect_kubernetes.pods import (
     create_namespaced_pod,
@@ -25,28 +26,44 @@ async def test_invalid_body_raises_error(kubernetes_credentials):
 
 async def test_create_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
     await create_namespaced_pod.fn(
-        body={"test": "a"},
+        body=V1Pod(**{"metadata": {"name": "test-pod"}}),
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
 
-    assert _mock_api_core_client.create_namespaced_pod.call_args[1]["body"] == {
-        "test": "a"
-    }
+    assert _mock_api_core_client.create_namespaced_pod.call_args[1][
+        "body"
+    ].metadata == {"name": "test-pod"}
     assert _mock_api_core_client.create_namespaced_pod.call_args[1]["a"] == "test"
 
 
 async def test_delete_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
     await delete_namespaced_pod.fn(
-        pod_name="test_pod",
-        a="test",
         kubernetes_credentials=kubernetes_credentials,
+        pod_name="test_pod",
+        body=V1DeleteOptions(grace_period_seconds=42),
+        a="test",
     )
     assert (
         _mock_api_core_client.delete_namespaced_pod.call_args[1]["namespace"]
         == "default"
     )
     assert _mock_api_core_client.delete_namespaced_pod.call_args[1]["a"] == "test"
+    assert (
+        _mock_api_core_client.delete_namespaced_pod.call_args[1][
+            "body"
+        ].grace_period_seconds
+        == 42
+    )
+
+
+async def test_bad_v1_delete_options(kubernetes_credentials, _mock_api_core_client):
+    with pytest.raises(TypeError):
+        await delete_namespaced_pod.fn(
+            kubernetes_credentials=kubernetes_credentials,
+            pod_name="test_pod",
+            body=V1DeleteOptions(skrrrt_skrrrt="yeehaw"),
+        )
 
 
 async def test_list_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
@@ -61,13 +78,13 @@ async def test_list_namespaced_pod(kubernetes_credentials, _mock_api_core_client
 
 async def test_patch_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
     await patch_namespaced_pod.fn(
-        body={"test": "a"},
+        body=V1Pod(**{"metadata": {"name": "test-pod"}}),
         pod_name="test_pod",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
     )
-    assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["body"] == {
-        "test": "a"
+    assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["body"].metadata == {
+        "name": "test-pod"
     }
     assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["name"] == "test_pod"
     assert _mock_api_core_client.patch_namespaced_pod.call_args[1]["a"] == "test"
@@ -109,7 +126,7 @@ async def test_read_namespaced_pod_logs(kubernetes_credentials, _mock_api_core_c
 async def test_replace_namespaced_pod(kubernetes_credentials, _mock_api_core_client):
     await replace_namespaced_pod.fn(
         pod_name="test_pod",
-        body={"test": "a"},
+        body=V1Pod(**{"metadata": {"name": "test-pod"}}),
         namespace="ns",
         a="test",
         kubernetes_credentials=kubernetes_credentials,
@@ -120,7 +137,19 @@ async def test_replace_namespaced_pod(kubernetes_credentials, _mock_api_core_cli
     assert (
         _mock_api_core_client.replace_namespaced_pod.call_args[1]["namespace"] == "ns"
     )
-    assert _mock_api_core_client.replace_namespaced_pod.call_args[1]["body"] == {
-        "test": "a"
-    }
+    assert _mock_api_core_client.replace_namespaced_pod.call_args[1][
+        "body"
+    ].metadata == {"name": "test-pod"}
     assert _mock_api_core_client.replace_namespaced_pod.call_args[1]["a"] == "test"
+
+
+@pytest.mark.parametrize(
+    "task_accepting_pod",
+    [create_namespaced_pod, patch_namespaced_pod, replace_namespaced_pod],
+)
+async def test_bad_v1_pod_kwargs(kubernetes_credentials, task_accepting_pod):
+    with pytest.raises(TypeError):
+        await task_accepting_pod.fn(
+            body=V1Pod(**{"random_not_real": "shabba-ranks"}),
+            kubernetes_credentials=kubernetes_credentials,
+        )

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -1,0 +1,15 @@
+import pytest
+
+from prefect_kubernetes.pods import (
+    create_namespaced_pod,
+    delete_namespaced_pod,
+    list_namespaced_pod,
+    patch_namespaced_pod,
+    read_namespaced_pod,
+    read_namespaced_pod_logs,
+    replace_namespaced_pod,
+)
+
+
+async def test_create_namespaced_pod(_mock_api_core_client, kubernetes_credentials):
+    await create_namespaced_pod.fn()


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-kubernetes! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Adds the `pod` tasks present in v1 Kubernetes Task Library, consolidates the client generation methods on `KubernetesCredentials` into a single `get_client` method and adds tests.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes #17 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
