### PR TITLE
refactor KubernetesJob and KubernetesJobRun to use existing task functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Jupyter notebook
 *.ipynb
+
+#direnv .envrc
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.3
+
+Released March 27, 2023
+
+### Updated
+- Refactor KubernetesJob and KubernetesJobRun to use existing task functions.
+
 ## 0.2.2
 
 Released March 24, 2023.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Refactor KubernetesJob and KubernetesJobRun to use existing task functions.
+- Refactor KubernetesJob and KubernetesJobRun to use existing task functions - [#43](https://github.com/PrefectHQ/prefect-kubernetes/pull/43)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Refactor KubernetesJob and KubernetesJobRun to use existing task functions.
 
 ### Deprecated
 
@@ -18,13 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-
-## 0.2.3
-
-Released March 27, 2023
-
-### Updated
-- Refactor KubernetesJob and KubernetesJobRun to use existing task functions.
 
 ## 0.2.2
 

--- a/prefect_kubernetes/jobs.py
+++ b/prefect_kubernetes/jobs.py
@@ -318,7 +318,7 @@ async def read_namespaced_job_status(
     Args:
         kubernetes_credentials: `KubernetesCredentials` block
             holding authentication needed to generate the required API client.
-        job_name: The name of a job to fetch the status.
+        job_name: The name of a job to fetch status for.
         namespace: The Kubernetes namespace to fetch status of job in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -9,6 +9,7 @@ from prefect_kubernetes.jobs import (
     list_namespaced_job,
     patch_namespaced_job,
     read_namespaced_job,
+    read_namespaced_job_status,
     replace_namespaced_job,
 )
 
@@ -111,6 +112,26 @@ async def test_replace_namespaced_job(kubernetes_credentials, _mock_api_batch_cl
     assert _mock_api_batch_client.replace_namespaced_job.call_args[1]["a"] == "test"
 
 
+async def test_read_namespaced_job_status(
+    kubernetes_credentials, _mock_api_batch_client
+):
+    await read_namespaced_job_status.fn(
+        job_name="test-job",
+        namespace="ns",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+    assert (
+        _mock_api_batch_client.read_namespaced_job_status.call_args[1]["name"]
+        == "test-job"
+    )
+    assert (
+        _mock_api_batch_client.read_namespaced_job_status.call_args[1]["namespace"]
+        == "ns"
+    )
+    assert _mock_api_batch_client.read_namespaced_job_status.call_args[1]["a"] == "test"
+
+
 async def test_job_block_from_job_yaml(kubernetes_credentials):
     job = KubernetesJob.from_yaml_file(
         credentials=kubernetes_credentials,
@@ -125,7 +146,6 @@ async def test_job_block_wait_never_called_raises(
     mock_create_namespaced_job,
     mock_delete_namespaced_job,
 ):
-
     job_run = await valid_kubernetes_job_block.trigger()
 
     with pytest.raises(


### PR DESCRIPTION

    - Use existing tasks to create, read, delete or fetch job status.
    - Use existing pods tasks to list pods and read pod logs.
    - Added read_namespaced_job_status task.

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
