### PR TITLE
support tasks for managing kubernetes custom resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.4
+
+Released March 27, 2023.
+
+### Added
+- Custom objects crud tasks for kubernetes custom resource definitions.
+
 ## 0.2.1
 
 Released February 17, 2023.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Released March 27, 2023.
 
 ### Added
-- Custom objects crud tasks for kubernetes custom resource definitions.
+- Custom objects crud tasks for kubernetes custom resource definitions. - [#45](https://github.com/PrefectHQ/prefect-kubernetes/pull/45)
 
 ## 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Custom objects crud tasks for kubernetes custom resource definitions. - [#45](https://github.com/PrefectHQ/prefect-kubernetes/pull/45)
 
 ### Changed
 
@@ -18,13 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-
-## 0.2.4
-
-Released March 27, 2023.
-
-### Added
-- Custom objects crud tasks for kubernetes custom resource definitions. - [#45](https://github.com/PrefectHQ/prefect-kubernetes/pull/45)
 
 ## 0.2.1
 

--- a/docs/custom_objects.md
+++ b/docs/custom_objects.md
@@ -1,0 +1,1 @@
+::: prefect_kubernetes.custom_objects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ watch:
 nav:
     - Home: index.md
     - Credentials: credentials.md
+    - Custom Objects: custom_objects.md
     - Deployments: deployments.md
     - Exceptions: exceptions.md
     - Flows: flows.md

--- a/prefect_kubernetes/credentials.py
+++ b/prefect_kubernetes/credentials.py
@@ -4,7 +4,14 @@ from contextlib import contextmanager
 from typing import Generator, Optional, Union
 
 from kubernetes import config as kube_config
-from kubernetes.client import ApiClient, AppsV1Api, BatchV1Api, Configuration, CoreV1Api
+from kubernetes.client import (
+    ApiClient,
+    AppsV1Api,
+    BatchV1Api,
+    Configuration,
+    CoreV1Api,
+    CustomObjectsApi,
+)
 from kubernetes.config.config_exception import ConfigException
 from prefect.blocks.core import Block
 from prefect.blocks.kubernetes import KubernetesClusterConfig
@@ -17,6 +24,7 @@ K8S_CLIENT_TYPES = {
     "apps": AppsV1Api,
     "batch": BatchV1Api,
     "core": CoreV1Api,
+    "custom_objects": CustomObjectsApi,
 }
 
 
@@ -45,7 +53,7 @@ class KubernetesCredentials(Block):
     @contextmanager
     def get_client(
         self,
-        client_type: Literal["apps", "batch", "core"],
+        client_type: Literal["apps", "batch", "core", "custom_objects"],
         configuration: Optional[Configuration] = None,
     ) -> Generator[KubernetesClient, None, None]:
         """Convenience method for retrieving a Kubernetes API client for deployment resources.

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -376,7 +376,7 @@ async def replace_namespaced_custom_object(
     plural: str,
     name: str,
     body: Dict[str, Any],
-    namespace: Optional[str] = "default",
+    namespace: str = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> object:
     """Task for replacing a namespaced custom resource.

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -260,7 +260,7 @@ async def list_namespaced_custom_object(
         group: The custom resource object's group
         version: The custom resource object's version
         plural: The custom resource object's plural
-        namespace: The Kubernetes namespace to list the custom resources.
+        namespace: The Kubernetes namespace to list custom resources for.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -1,0 +1,423 @@
+from typing import Any, Dict, Optional
+
+from prefect import task
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
+
+from prefect_kubernetes.credentials import KubernetesCredentials
+
+
+@task
+async def create_namespaced_custom_object(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    body: Dict[str, Any],
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for creating a namespaced custom object.
+
+    Args:
+        kubernetes_credentials: `KubernetesCredentials` block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        body: A Dict containing the custom resource object's specification.
+        namespace: The Kubernetes namespace to create this custom object in.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+    Returns: object containing the custom resource created by this task.
+
+    Example:
+        Create a custom object in the default namespace:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import create_namespaced_custom_object
+
+        @flow
+        def kubernetes_orchestrator():
+            custom_object_metadata = create_namespaced_custom_object(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                body={
+                    'api': 'crd-version',
+                    'kind': 'crd-kind',
+                    'metadata': {
+                        'name': 'crd-name',
+                    },
+                },
+            )
+        ```
+    """
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.create_namespaced_custom_object,
+            group=group,
+            version=version,
+            plural=plural,
+            body=body,
+            namespace=namespace,
+            **kube_kwargs,
+        )
+
+
+@task
+async def delete_namespaced_custom_object(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for deleting a namespaced custom object.
+
+    Args:
+        kubernetes_credentials: `KubernetesCredentials` block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        name: The name of a custom object to delete.
+        namespace: The Kubernetes namespace to create this custom object in.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+
+    Returns: object containing the custom resource deleted by this task.
+
+    Example:
+        Delete "my-custom-object" in the default namespace:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import delete_namespaced_custom_object
+
+        @flow
+        def kubernetes_orchestrator():
+            custom_object_metadata = delete_namespaced_custom_object(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                name="my-custom-object",
+            )
+        ```
+    """
+
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.delete_namespaced_custom_object,
+            group=group,
+            version=version,
+            plural=plural,
+            name=name,
+            namespace=namespace,
+            **kube_kwargs,
+        )
+
+
+@task
+async def get_namespaced_custom_object(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for reading a namespaced Kubernetes custom object.
+
+    Args:
+        kubernetes_credentials: `KubernetesCredentials` block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        name: The name of a custom object to read.
+        namespace: The Kubernetes namespace to read this custom resource is in.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+    Raises:
+        ValueError: if `name` is `None`.
+
+    Returns: object containing the custom resource specification.
+
+    Example:
+        Read "my-custom-object" in the default namespace:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import get_namespaced_custom_object
+
+        @flow
+        def kubernetes_orchestrator():
+            custom_object_metadata = get_namespaced_custom_object(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                name="my-custom-object",
+            )
+        ```
+    """
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.get_namespaced_custom_object,
+            group=group,
+            version=version,
+            plural=plural,
+            name=name,
+            namespace=namespace,
+            **kube_kwargs,
+        )
+
+
+@task
+async def get_namespaced_custom_object_status(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for fetching status of a namespaced custom object.
+
+    Args:
+        kubernetes_credentials: `KubernetesCredentials` block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        name: The name of a custom object to read.
+        namespace: The Kubernetes namespace to read status of the custom resource is in.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+    Returns: object containing the custom-object specification with status.
+
+    Example:
+        Fetch status of "my-custom-object" in the default namespace:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import get_namespaced_custom_object_status
+
+        @flow
+        def kubernetes_orchestrator():
+            custom_object_metadata = get_namespaced_custom_object_status(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                name="my-custom-object",
+            )
+        ```
+    """
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.get_namespaced_custom_object_status,
+            group=group,
+            version=version,
+            plural=plural,
+            name=name,
+            namespace=namespace,
+            **kube_kwargs,
+        )
+
+
+@task
+async def list_namespaced_custom_object(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for listing namespaced custom objects.
+
+    Args:
+        kubernetes_credentials: `KubernetesCredentials` block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        namespace: The Kubernetes namespace to list the custom resources.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+    Returns: object containing a list of custom resources.
+
+    Example:
+        List custom resources in "my-namespace":
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import list_namespaced_custom_object
+
+        @flow
+        def kubernetes_orchestrator():
+            namespaced_custom_objects_list = list_namespaced_custom_object(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                namespace="my-namespace",
+            )
+        ```
+    """
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.list_namespaced_custom_object,
+            group=group,
+            version=version,
+            plural=plural,
+            namespace=namespace,
+            **kube_kwargs,
+        )
+
+
+@task
+async def patch_namespaced_custom_object(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    body: Dict[str, Any],
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for patching a namespaced custom resource.
+
+    Args:
+        kubernetes_credentials: KubernetesCredentials block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        name: The name of a custom object to patch.
+        body: A Dict containing the custom resource object's patch.
+        namespace: The Kubernetes namespace to patch the custom resources.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+    Raises: ValueError: if `body` is `None`.
+
+    Returns: object containing the custom resource specification after the patch gets applied.
+
+    Example:
+        Patch "my-custom-object" in the default namespace:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import patch_namespaced_custom_object
+
+        @flow
+        def kubernetes_orchestrator():
+            custom_object_metadata = patch_namespaced_custom_object(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                name="my-custom-object",
+                body={
+                    'api': 'crd-version',
+                    'kind': 'crd-kind',
+                    'metadata': {
+                        'name': 'my-custom-object',
+                    },
+                },
+            )
+        ```
+    """
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.patch_namespaced_custom_object,
+            group=group,
+            version=version,
+            plural=plural,
+            name=name,
+            body=body,
+            namespace=namespace,
+            **kube_kwargs,
+        )
+
+
+@task
+async def replace_namespaced_custom_object(
+    kubernetes_credentials: KubernetesCredentials,
+    group: str,
+    version: str,
+    plural: str,
+    name: str,
+    body: Dict[str, Any],
+    namespace: Optional[str] = "default",
+    **kube_kwargs: Dict[str, Any],
+) -> object:
+    """Task for replacing a namespaced custom resource.
+
+    Args:
+        kubernetes_credentials: KubernetesCredentials block
+            holding authentication needed to generate the required API client.
+        group: The custom resource object's group
+        version: The custom resource object's version
+        plural: The custom resource object's plural
+        name: The name of a custom object to patch.
+        body: A Dict containing the custom resource object's specification.
+        namespace: The Kubernetes namespace to patch the custom resources.
+        **kube_kwargs: Optional extra keyword arguments to pass to the
+            Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
+
+    Raises: ValueError: if `body` is `None`.
+
+    Returns: object containing the custom resource specification after the replacement.
+
+    Example:
+        Replace "my-custom-object" in the default namespace:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes.credentials import KubernetesCredentials
+        from prefect_kubernetes.custom_objects import replace_namespaced_custom_object
+
+        @flow
+        def kubernetes_orchestrator():
+            custom_object_metadata = replace_namespaced_custom_object(
+                kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
+                group="crd-group",
+                version="crd-version",
+                plural="crd-plural",
+                name="my-custom-object",
+                body={
+                    'api': 'crd-version',
+                    'kind': 'crd-kind',
+                    'metadata': {
+                        'name': 'my-custom-object',
+                    },
+                },
+            )
+        ```
+    """
+    with kubernetes_credentials.get_client("custom_objects") as custom_objects_client:
+        return await run_sync_in_worker_thread(
+            custom_objects_client.replace_namespaced_custom_object,
+            group=group,
+            version=version,
+            plural=plural,
+            name=name,
+            body=body,
+            namespace=namespace,
+            **kube_kwargs,
+        )

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -145,7 +145,7 @@ async def get_namespaced_custom_object(
         version: The custom resource object's version
         plural: The custom resource object's plural
         name: The name of a custom object to read.
-        namespace: The Kubernetes namespace to read this custom resource is in.
+        namespace: The Kubernetes namespace the custom resource is in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -29,7 +29,8 @@ async def create_namespaced_custom_object(
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 
-    Returns: object containing the custom resource created by this task.
+    Returns:
+        object containing the custom resource created by this task.
 
     Example:
         Create a custom object in the default namespace:
@@ -91,7 +92,8 @@ async def delete_namespaced_custom_object(
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 
 
-    Returns: object containing the custom resource deleted by this task.
+    Returns:
+        object containing the custom resource deleted by this task.
 
     Example:
         Delete "my-custom-object" in the default namespace:
@@ -150,7 +152,8 @@ async def get_namespaced_custom_object(
     Raises:
         ValueError: if `name` is `None`.
 
-    Returns: object containing the custom resource specification.
+    Returns:
+        object containing the custom resource specification.
 
     Example:
         Read "my-custom-object" in the default namespace:
@@ -205,14 +208,17 @@ async def get_namespaced_custom_object_status(
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 
-    Returns: object containing the custom-object specification with status.
+    Returns:
+        object containing the custom-object specification with status.
 
     Example:
         Fetch status of "my-custom-object" in the default namespace:
         ```python
         from prefect import flow
         from prefect_kubernetes.credentials import KubernetesCredentials
-        from prefect_kubernetes.custom_objects import get_namespaced_custom_object_status
+        from prefect_kubernetes.custom_objects import (
+            get_namespaced_custom_object_status,
+        )
 
         @flow
         def kubernetes_orchestrator():
@@ -258,7 +264,8 @@ async def list_namespaced_custom_object(
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 
-    Returns: object containing a list of custom resources.
+    Returns:
+        object containing a list of custom resources.
 
     Example:
         List custom resources in "my-namespace":
@@ -314,16 +321,21 @@ async def patch_namespaced_custom_object(
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 
-    Raises: ValueError: if `body` is `None`.
+    Raises:
+        ValueError: if `body` is `None`.
 
-    Returns: object containing the custom resource specification after the patch gets applied.
+    Returns:
+        object containing the custom resource specification
+        after the patch gets applied.
 
     Example:
         Patch "my-custom-object" in the default namespace:
         ```python
         from prefect import flow
         from prefect_kubernetes.credentials import KubernetesCredentials
-        from prefect_kubernetes.custom_objects import patch_namespaced_custom_object
+        from prefect_kubernetes.custom_objects import (
+            patch_namespaced_custom_object,
+        )
 
         @flow
         def kubernetes_orchestrator():
@@ -381,9 +393,11 @@ async def replace_namespaced_custom_object(
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 
-    Raises: ValueError: if `body` is `None`.
+    Raises:
+        ValueError: if `body` is `None`.
 
-    Returns: object containing the custom resource specification after the replacement.
+    Returns:
+        object containing the custom resource specification after the replacement.
 
     Example:
         Replace "my-custom-object" in the default namespace:

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -25,7 +25,7 @@ async def create_namespaced_custom_object(
         version: The custom resource object's version
         plural: The custom resource object's plural
         body: A Dict containing the custom resource object's specification.
-        namespace: The Kubernetes namespace to create this custom object in.
+        namespace: The Kubernetes namespace to create the custom object in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -317,7 +317,7 @@ async def patch_namespaced_custom_object(
         plural: The custom resource object's plural
         name: The name of a custom object to patch.
         body: A Dict containing the custom resource object's patch.
-        namespace: The Kubernetes namespace to patch the custom resources.
+        namespace: The custom resource's Kubernetes namespace.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -204,7 +204,7 @@ async def get_namespaced_custom_object_status(
         version: The custom resource object's version
         plural: The custom resource object's plural
         name: The name of a custom object to read.
-        namespace: The Kubernetes namespace to read status of the custom resource is in.
+        namespace: The Kubernetes namespace the custom resource is in.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -304,7 +304,7 @@ async def patch_namespaced_custom_object(
     plural: str,
     name: str,
     body: Dict[str, Any],
-    namespace: Optional[str] = "default",
+    namespace: str = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> object:
     """Task for patching a namespaced custom resource.

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -249,7 +249,7 @@ async def list_namespaced_custom_object(
     group: str,
     version: str,
     plural: str,
-    namespace: Optional[str] = "default",
+    namespace: str = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> object:
     """Task for listing namespaced custom objects.

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -192,7 +192,7 @@ async def get_namespaced_custom_object_status(
     version: str,
     plural: str,
     name: str,
-    namespace: Optional[str] = "default",
+    namespace: str = "default",
     **kube_kwargs: Dict[str, Any],
 ) -> object:
     """Task for fetching status of a namespaced custom object.

--- a/prefect_kubernetes/custom_objects.py
+++ b/prefect_kubernetes/custom_objects.py
@@ -387,9 +387,9 @@ async def replace_namespaced_custom_object(
         group: The custom resource object's group
         version: The custom resource object's version
         plural: The custom resource object's plural
-        name: The name of a custom object to patch.
+        name: The name of a custom object to replace.
         body: A Dict containing the custom resource object's specification.
-        namespace: The Kubernetes namespace to patch the custom resources.
+        namespace: The custom resource's Kubernetes namespace.
         **kube_kwargs: Optional extra keyword arguments to pass to the
             Kubernetes API (e.g. `{"pretty": "...", "dry_run": "..."}`).
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,5 @@
 import pytest
-from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api
+from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api, CustomObjectsApi
 
 
 @pytest.mark.parametrize(
@@ -8,10 +8,10 @@ from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api
         ("apps", AppsV1Api),
         ("batch", BatchV1Api),
         ("core", CoreV1Api),
+        ("custom_objects", CustomObjectsApi),
     ],
 )
 def test_client_return_type(kubernetes_credentials, resource_type, client_type):
-
     with kubernetes_credentials.get_client(resource_type) as client:
         assert isinstance(client, client_type)
 

--- a/tests/test_custom_objects.py
+++ b/tests/test_custom_objects.py
@@ -1,0 +1,370 @@
+import pytest
+from kubernetes.client.exceptions import ApiValueError
+
+from prefect_kubernetes.custom_objects import (
+    create_namespaced_custom_object,
+    delete_namespaced_custom_object,
+    get_namespaced_custom_object,
+    get_namespaced_custom_object_status,
+    list_namespaced_custom_object,
+    patch_namespaced_custom_object,
+    replace_namespaced_custom_object,
+)
+
+
+async def test_null_body_raises_error(kubernetes_credentials):
+    with pytest.raises(ApiValueError):
+        await create_namespaced_custom_object.fn(
+            group="my-group",
+            version="v1",
+            plural="ops",
+            body=None,
+            kubernetes_credentials=kubernetes_credentials,
+        )
+    with pytest.raises(ApiValueError):
+        await patch_namespaced_custom_object.fn(
+            group="my-group",
+            version="v1",
+            plural="ops",
+            name="test-name",
+            body=None,
+            kubernetes_credentials=kubernetes_credentials,
+        )
+    with pytest.raises(ApiValueError):
+        await replace_namespaced_custom_object.fn(
+            group="my-group",
+            version="v1",
+            plural="ops",
+            name="test-name",
+            body=None,
+            kubernetes_credentials=kubernetes_credentials,
+        )
+
+
+async def test_create_namespaced_crd(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await create_namespaced_custom_object.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        body={
+            "api": "v1",
+            "kind": "op",
+            "metadata": {
+                "name": "test",
+            },
+        },
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.create_namespaced_custom_object.call_args[1][
+            "a"
+        ]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.create_namespaced_custom_object.call_args[1][
+            "group"
+        ]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.create_namespaced_custom_object.call_args[1][
+            "version"
+        ]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.create_namespaced_custom_object.call_args[1][
+            "plural"
+        ]
+        == "ops"
+    )
+    # We can't have models for Custom Resources.
+    assert _mock_api_custom_objects_client.create_namespaced_custom_object.call_args[1][
+        "body"
+    ]["metadata"] == {"name": "test"}
+
+
+async def test_get_namespaced_custom_object(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await get_namespaced_custom_object.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        name="test-name",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object.call_args[1]["a"]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object.call_args[1][
+            "group"
+        ]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object.call_args[1][
+            "version"
+        ]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object.call_args[1][
+            "plural"
+        ]
+        == "ops"
+    )
+    # We can't have models for Custom Resources.
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object.call_args[1][
+            "name"
+        ]
+        == "test-name"
+    )
+
+
+async def test_get_namespaced_custom_object_status(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await get_namespaced_custom_object_status.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        name="test-name",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object_status.call_args[
+            1
+        ]["a"]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object_status.call_args[
+            1
+        ]["group"]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object_status.call_args[
+            1
+        ]["version"]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object_status.call_args[
+            1
+        ]["plural"]
+        == "ops"
+    )
+    # We can't have models for Custom Resources.
+    assert (
+        _mock_api_custom_objects_client.get_namespaced_custom_object_status.call_args[
+            1
+        ]["name"]
+        == "test-name"
+    )
+
+
+async def test_delete_namespaced_custom_object(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await delete_namespaced_custom_object.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        name="test-name",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.delete_namespaced_custom_object.call_args[1][
+            "a"
+        ]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.delete_namespaced_custom_object.call_args[1][
+            "group"
+        ]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.delete_namespaced_custom_object.call_args[1][
+            "version"
+        ]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.delete_namespaced_custom_object.call_args[1][
+            "plural"
+        ]
+        == "ops"
+    )
+    # We can't have models for Custom Resources.
+    assert (
+        _mock_api_custom_objects_client.delete_namespaced_custom_object.call_args[1][
+            "name"
+        ]
+        == "test-name"
+    )
+
+
+async def test_list_namespaced_custom_object(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await list_namespaced_custom_object.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.list_namespaced_custom_object.call_args[1]["a"]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.list_namespaced_custom_object.call_args[1][
+            "group"
+        ]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.list_namespaced_custom_object.call_args[1][
+            "version"
+        ]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.list_namespaced_custom_object.call_args[1][
+            "plural"
+        ]
+        == "ops"
+    )
+
+
+async def test_patch_namespaced_custom_object(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await patch_namespaced_custom_object.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        name="test-name",
+        body={
+            "api": "v1",
+            "kind": "op",
+            "metadata": {
+                "name": "test",
+            },
+        },
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.patch_namespaced_custom_object.call_args[1]["a"]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.patch_namespaced_custom_object.call_args[1][
+            "group"
+        ]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.patch_namespaced_custom_object.call_args[1][
+            "version"
+        ]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.patch_namespaced_custom_object.call_args[1][
+            "plural"
+        ]
+        == "ops"
+    )
+    assert (
+        _mock_api_custom_objects_client.patch_namespaced_custom_object.call_args[1][
+            "name"
+        ]
+        == "test-name"
+    )
+    assert _mock_api_custom_objects_client.patch_namespaced_custom_object.call_args[1][
+        "body"
+    ]["metadata"] == {"name": "test"}
+
+
+async def test_replace_namespaced_custom_object(
+    kubernetes_credentials, _mock_api_custom_objects_client
+):
+    await replace_namespaced_custom_object.fn(
+        group="my-group",
+        version="v1",
+        plural="ops",
+        name="test-name",
+        body={
+            "api": "v1",
+            "kind": "op",
+            "metadata": {
+                "name": "test",
+            },
+        },
+        a="test",
+        kubernetes_credentials=kubernetes_credentials,
+    )
+
+    assert (
+        _mock_api_custom_objects_client.replace_namespaced_custom_object.call_args[1][
+            "a"
+        ]
+        == "test"
+    )
+
+    assert (
+        _mock_api_custom_objects_client.replace_namespaced_custom_object.call_args[1][
+            "group"
+        ]
+        == "my-group"
+    )
+    assert (
+        _mock_api_custom_objects_client.replace_namespaced_custom_object.call_args[1][
+            "version"
+        ]
+        == "v1"
+    )
+    assert (
+        _mock_api_custom_objects_client.replace_namespaced_custom_object.call_args[1][
+            "plural"
+        ]
+        == "ops"
+    )
+    assert (
+        _mock_api_custom_objects_client.replace_namespaced_custom_object.call_args[1][
+            "name"
+        ]
+        == "test-name"
+    )
+    assert _mock_api_custom_objects_client.replace_namespaced_custom_object.call_args[
+        1
+    ]["body"]["metadata"] == {"name": "test"}


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #44 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
Mkdocs:
<img width="1366" alt="Screenshot 2023-03-26 at 12 08 01 AM" src="https://user-images.githubusercontent.com/1139145/227735819-edc46b4f-39f5-418a-9623-8866d4a11e2e.png">

Service Integration tests:
<img width="1438" alt="Screenshot 2023-03-26 at 12 20 12 AM" src="https://user-images.githubusercontent.com/1139145/227735909-b58fa1db-b5f5-4787-bac0-62cd5a21da0a.png">
<!--


Any relevant screenshots
  - The updated docs page from `mkdocs [serve`.]
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
