### PR TITLE
Adds advanced usage docs

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -44,9 +44,9 @@ to force column width */
     border-radius: 5px;
 }
 
-.experimental::before {
+.beta::before {
     background-color: #FCD14E;
-    content: "Experimental";
+    content: "Beta";
 }
 
 .cloud::before {


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Adds short section on how to customize the job manifest used to create Kubernetes jobs via the base job template of a work pool

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![Screenshot 2023-04-06 at 6 21 16 AM](https://user-images.githubusercontent.com/12350579/230362752-9028ea8b-a145-41e2-8f43-4a8305976f8c.png)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
