### PR TITLE
Create `KubernetesEventsReplicator` and replicate events while watching jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.6
+
+Released April ??th, 2023.
+
+### Added
+
+- `KubernetesEventReplicator` which replicates kubernetes pod events to Prefect events.
+
 ## 0.2.5
 
 Released April 20th, 2023.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.2.6
 
-Released April ??th, 2023.
+Released April 28th, 2023.
 
 ### Added
 

--- a/prefect_kubernetes/events.py
+++ b/prefect_kubernetes/events.py
@@ -1,0 +1,121 @@
+import atexit
+import sys
+import threading
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from prefect.events import Event, RelatedResource, emit_event
+from prefect.utilities.importtools import lazy_import
+
+if TYPE_CHECKING:
+    import kubernetes
+    import kubernetes.client
+    import kubernetes.watch
+    from kubernetes.client import ApiClient, V1Pod
+else:
+    kubernetes = lazy_import("kubernetes")
+
+EVICTED_REASONS = {
+    "OOMKilled",
+    "CrashLoopBackoff",
+    "Error",
+    "Completed",
+    "DeadlineExceeded",
+    "ImageGCFailed",
+    "NodeLost",
+    "NodeOutOfDisk",
+}
+
+
+class KubernetesEventsReplicator:
+    def __init__(
+        self,
+        client: "ApiClient",
+        job_name: str,
+        namespace: str,
+        worker_resource: Dict[str, str],
+        related_resources: List[RelatedResource],
+    ):
+        self._client = client
+        self._job_name = job_name
+        self._namespace = namespace
+
+        # All events emitted by this replicator have the pod itself as the
+        # resource. The `worker_resource` is what the worker uses when it's
+        # the primary resource, so here it's turned into a related resource
+        # instead.
+        worker_resource["prefect.resource.role"] = "worker"
+        worker_related_resource = RelatedResource(__root__=worker_resource)
+        self._related_resources = related_resources + [worker_related_resource]
+
+        self._watch = kubernetes.watch.Watch()
+        self._thread = threading.Thread(target=self._replicate_pod_events)
+
+        self._state = "READY"
+
+        atexit.register(self.stop)
+
+    def __enter__(self):
+        self._thread.start()
+        self._state = "STARTED"
+
+    def __exit__(self, *args, **kwargs):
+        self.stop()
+
+    def stop(self):
+        if self._thread.is_alive():
+            self._watch.stop()
+            self._thread.join()
+            self._state = "STOPPED"
+
+    def _pod_as_resource(self, pod: "V1Pod") -> Dict[str, str]:
+        return {
+            "prefect.resource.id": f"prefect.kubernetes.pod.{pod.metadata.uid}",
+            "prefect.resource.name": pod.metadata.name,
+            "kubernetes.namespace": pod.metadata.namespace,
+        }
+
+    def _replicate_pod_events(self):
+        seen_phases = set()
+        last_event = None
+
+        try:
+            core_client = kubernetes.client.CoreV1Api(api_client=self._client)
+            for event in self._watch.stream(
+                func=core_client.list_namespaced_pod,
+                namespace=self._namespace,
+                label_selector=f"job-name={self._job_name}",
+            ):
+                phase = event["object"].status.phase
+
+                if phase not in seen_phases:
+                    last_event = self._emit_pod_event(event, last_event=last_event)
+                    seen_phases.add(phase)
+        finally:
+            self._client.rest_client.pool_manager.clear()
+
+    def _emit_pod_event(
+        self,
+        pod_event: Dict,
+        last_event: Optional[Event] = None,
+    ) -> Event:
+        pod_event_type = pod_event["type"]
+        pod: "V1Pod" = pod_event["object"]
+        pod_phase = pod.status.phase
+
+        resource = self._pod_as_resource(pod)
+
+        if pod_event_type == "MODIFIED" and pod_phase == "Failed":
+            for container_status in pod.status.container_statuses:
+                if container_status.state.terminated.reason in EVICTED_REASONS:
+                    pod_phase = "evicted"
+                    resource[
+                        "kubernetes.reason"
+                    ] = container_status.state.terminated.reason
+                    break
+
+        return emit_event(
+            event=f"prefect.kubernetes.pod.{pod_phase.lower()}",
+            resource=resource,
+            related=self._related_resources,
+            follows=last_event,
+        )

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -97,9 +97,9 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
 import anyio.abc
 from prefect.blocks.kubernetes import KubernetesClusterConfig
 from prefect.docker import get_prefect_image_name
-from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.events import RelatedResource
 from prefect.events.related import object_as_related_resource, tags_as_related_resources
+from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.utilities.asyncutils import run_sync_in_worker_thread

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -400,6 +400,8 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
         related = []
 
         for kind, obj in self._related_objects.items():
+            # TODO: Remove this method once we've updated the Prefect core side
+            # to ignore objects that are None.
             if not obj:
                 continue
             if hasattr(obj, "tags"):

--- a/tests/test_events_replicator.py
+++ b/tests/test_events_replicator.py
@@ -1,0 +1,440 @@
+import time
+import copy
+import threading
+import pytest
+from unittest.mock import MagicMock, call, patch
+
+from kubernetes.client import ApiClient, CoreV1Api, V1Pod
+from prefect.events import Event, RelatedResource, emit_event
+from prefect.utilities.importtools import lazy_import
+from prefect_kubernetes.events import EVICTED_REASONS, KubernetesEventsReplicator
+
+kubernetes = lazy_import("kubernetes")
+
+
+@pytest.fixture
+def client():
+    return MagicMock()
+
+
+@pytest.fixture
+def pod():
+    pod = MagicMock(spec=V1Pod)
+    pod.metadata.name = "test-pod"
+    pod.metadata.namespace = "test-namespace"
+    pod.metadata.uid = "1234"
+    return pod
+
+
+@pytest.fixture
+def pending_pod(pod):
+    pending_pod = copy.deepcopy(pod)
+    pending_pod.status.phase = "Pending"
+    return pending_pod
+
+
+@pytest.fixture
+def running_pod(pod):
+    running_pod = copy.deepcopy(pod)
+    running_pod.status.phase = "Running"
+    return running_pod
+
+
+@pytest.fixture
+def succeeded_pod(pod):
+    succeeded_pod = copy.deepcopy(pod)
+    succeeded_pod.status.phase = "Succeeded"
+    return succeeded_pod
+
+
+@pytest.fixture
+def failed_pod(pod):
+    failed_pod = copy.deepcopy(pod)
+    failed_pod.status.phase = "Failed"
+    return failed_pod
+
+
+@pytest.fixture
+def evicted_pod(pod):
+    container_status = MagicMock()
+    container_status.state.terminated.reason = "OOMKilled"
+
+    assert container_status.state.terminated.reason in EVICTED_REASONS
+
+    evicted_pod = copy.deepcopy(pod)
+    evicted_pod.status.phase = "Failed"
+    evicted_pod.status.container_statuses = [container_status]
+
+    return evicted_pod
+
+
+@pytest.fixture
+def successful_pod_stream(pending_pod, running_pod, succeeded_pod):
+    return [
+        {
+            "type": "ADDED",
+            "object": pending_pod,
+        },
+        {
+            "type": "MODIFIED",
+            "object": running_pod,
+        },
+        {
+            "type": "MODIFIED",
+            "object": succeeded_pod,
+        },
+    ]
+
+
+@pytest.fixture
+def failed_pod_stream(pending_pod, running_pod, failed_pod):
+    return [
+        {
+            "type": "ADDED",
+            "object": pending_pod,
+        },
+        {
+            "type": "MODIFIED",
+            "object": running_pod,
+        },
+        {
+            "type": "MODIFIED",
+            "object": failed_pod,
+        },
+    ]
+
+
+@pytest.fixture
+def evicted_pod_stream(pending_pod, running_pod, evicted_pod):
+    return [
+        {
+            "type": "ADDED",
+            "object": pending_pod,
+        },
+        {
+            "type": "MODIFIED",
+            "object": running_pod,
+        },
+        {
+            "type": "MODIFIED",
+            "object": evicted_pod,
+        },
+    ]
+
+
+@pytest.fixture
+def worker_resource():
+    return {"prefect.resource.id": "prefect.worker.my-k8s-worker"}
+
+
+@pytest.fixture
+def related_resources():
+    return [
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": "prefect.flow-run.1234",
+                "prefect.resource.role": "flow-run",
+            }
+        )
+    ]
+
+
+@pytest.fixture
+def replicator(client, worker_resource, related_resources):
+    return KubernetesEventsReplicator(
+        client=client,
+        job_name="test-job",
+        namespace="test-namespace",
+        worker_resource=worker_resource,
+        related_resources=related_resources,
+    )
+
+
+def test_lifecycle(replicator):
+    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
+    mock_thread = MagicMock(spec=threading.Thread)
+
+    with patch.object(replicator, "_watch", mock_watch):
+        with patch.object(replicator, "_thread", mock_thread):
+            with replicator:
+                assert replicator._state == "STARTED"
+                mock_thread.start.assert_called_once_with()
+                mock_thread.reset_mock()
+
+    assert replicator._state == "STOPPED"
+    mock_watch.stop.assert_called_once_with()
+    mock_thread.join.assert_called_once_with()
+
+
+def test_replicate_successful_pod_events(replicator, successful_pod_stream):
+    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
+    mock_watch.stream.return_value = successful_pod_stream
+
+    event_count = 0
+
+    def event(*args, **kwargs):
+        nonlocal event_count
+        event_count += 1
+        return event_count
+
+    with patch("prefect_kubernetes.events.emit_event", side_effect=event) as mock_emit:
+        with patch.object(replicator, "_watch", mock_watch):
+            with replicator:
+                time.sleep(0.3)
+
+    mock_emit.assert_has_calls(
+        [
+            call(
+                event="prefect.kubernetes.pod.pending",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=None,
+            ),
+            call(
+                event="prefect.kubernetes.pod.running",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=1,
+            ),
+            call(
+                event="prefect.kubernetes.pod.succeeded",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=2,
+            ),
+        ]
+    )
+
+
+def test_replicate_failed_pod_events(replicator, failed_pod_stream):
+    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
+    mock_watch.stream.return_value = failed_pod_stream
+
+    event_count = 0
+
+    def event(*args, **kwargs):
+        nonlocal event_count
+        event_count += 1
+        return event_count
+
+    with patch("prefect_kubernetes.events.emit_event", side_effect=event) as mock_emit:
+        with patch.object(replicator, "_watch", mock_watch):
+            with replicator:
+                time.sleep(0.3)
+
+    mock_emit.assert_has_calls(
+        [
+            call(
+                event="prefect.kubernetes.pod.pending",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=None,
+            ),
+            call(
+                event="prefect.kubernetes.pod.running",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=1,
+            ),
+            call(
+                event="prefect.kubernetes.pod.failed",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=2,
+            ),
+        ]
+    )
+
+
+def test_replicate_evicted_pod_events(replicator, evicted_pod_stream):
+    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
+    mock_watch.stream.return_value = evicted_pod_stream
+
+    event_count = 0
+
+    def event(*args, **kwargs):
+        nonlocal event_count
+        event_count += 1
+        return event_count
+
+    with patch("prefect_kubernetes.events.emit_event", side_effect=event) as mock_emit:
+        with patch.object(replicator, "_watch", mock_watch):
+            with replicator:
+                time.sleep(0.3)
+
+    mock_emit.assert_has_calls(
+        [
+            call(
+                event="prefect.kubernetes.pod.pending",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=None,
+            ),
+            call(
+                event="prefect.kubernetes.pod.running",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=1,
+            ),
+            call(
+                event="prefect.kubernetes.pod.evicted",
+                resource={
+                    "prefect.resource.id": "prefect.kubernetes.pod.1234",
+                    "prefect.resource.name": "test-pod",
+                    "kubernetes.namespace": "test-namespace",
+                    "kubernetes.reason": "OOMKilled",
+                },
+                related=[
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.flow-run.1234",
+                            "prefect.resource.role": "flow-run",
+                        }
+                    ),
+                    RelatedResource(
+                        __root__={
+                            "prefect.resource.id": "prefect.worker.my-k8s-worker",
+                            "prefect.resource.role": "worker",
+                        }
+                    ),
+                ],
+                follows=2,
+            ),
+        ]
+    )

--- a/tests/test_events_replicator.py
+++ b/tests/test_events_replicator.py
@@ -1,12 +1,13 @@
-import time
 import copy
 import threading
-import pytest
+import time
 from unittest.mock import MagicMock, call, patch
 
-from kubernetes.client import ApiClient, CoreV1Api, V1Pod
-from prefect.events import Event, RelatedResource, emit_event
+import pytest
+from kubernetes.client import V1Pod
+from prefect.events import RelatedResource
 from prefect.utilities.importtools import lazy_import
+
 from prefect_kubernetes.events import EVICTED_REASONS, KubernetesEventsReplicator
 
 kubernetes = lazy_import("kubernetes")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -127,7 +127,10 @@ def _mock_pods_stream_that_returns_running_pod(*args, **kwargs):
     job = MagicMock(spec=kubernetes.client.V1Job)
     job.status.completion_time = pendulum.now("utc").timestamp()
 
-    return [{"object": job_pod}, {"object": job}]
+    return [
+        {"object": job_pod, "type": "MODIFIED"},
+        {"object": job, "type": "MODIFIED"},
+    ]
 
 
 from_template_and_values_cases = [


### PR DESCRIPTION
This creates a class called `KubernetesEventsReplicator`, this class spins up a thread and watches the event stream from kubernetes and replicates pod events to Prefect Events. 

### Example
Here are two example events, the first is a pod 'running' event, which is the same structure that everything except the 'evicted' event:

```json
{
  "event": "prefect.kubernetes.pod.running",
  "related": [
    {
      "prefect.resource.id": "prefect.deployment.8eb5492d-ebcc-44ac-878a-40d07d98aae7",
      "prefect.resource.name": "happy_little_tree",
      "prefect.resource.role": "deployment"
    },
    {
      "prefect.resource.id": "prefect.flow.b0478707-80b6-45ec-88fa-5fa4bfd45980",
      "prefect.resource.name": "happy",
      "prefect.resource.role": "flow"
    },
    {
      "prefect.resource.id": "prefect.flow-run.f02a1a9a-c989-42e6-9cd4-dad616ed6ec9",
      "prefect.resource.name": "granite-dodo",
      "prefect.resource.role": "flow-run"
    },
    {
      "prefect.resource.id": "prefect.work-pool.b96987f9-5141-4c16-b40c-564190baddcf",
      "prefect.resource.name": "my-k8s-pool",
      "prefect.resource.role": "work-pool"
    },
    {
      "prefect.version": "2.10.5",
      "prefect.resource.id": "prefect.worker.kubernetes.k8s-worker",
      "prefect.worker-type": "kubernetes",
      "prefect.resource.name": "k8s-worker",
      "prefect.resource.role": "worker"
    }
  ],
  "resource": {
    "prefect.resource.id": "prefect.kubernetes.pod.010e3a06-a13c-47a4-bb6f-82974e7136b6",
    "kubernetes.namespace": "default",
    "prefect.resource.name": "granite-dodo-rcjpt-lnbmw"
  },
  "workspace": "d3a6209b-65a4-465e-b018-8b2433f657be"
}
```

The second is the evicted event, which is very similar, except that it adds a `kubernetes.reason` to the resource:

```json
{
  ...
  "event": "prefect.kubernetes.pod.evicted",
  "related": [
    {
      "prefect.resource.id": "prefect.deployment.8eb5492d-ebcc-44ac-878a-40d07d98aae7",
      "prefect.resource.name": "happy_little_tree",
      "prefect.resource.role": "deployment"
    },
    {
      "prefect.resource.id": "prefect.flow.b0478707-80b6-45ec-88fa-5fa4bfd45980",
      "prefect.resource.name": "happy",
      "prefect.resource.role": "flow"
    },
    {
      "prefect.resource.id": "prefect.flow-run.200a8804-60b7-403a-b89d-c6995f88cce2",
      "kubernetes.namespace": "default",
      "prefect.resource.name": "venomous-tody",
      "prefect.resource.role": "flow-run"
    },
    {
      "prefect.resource.id": "prefect.work-pool.b96987f9-5141-4c16-b40c-564190baddcf",
      "prefect.resource.name": "my-k8s-pool",
      "prefect.resource.role": "work-pool"
    },
    {
      "prefect.version": "2.10.5",
      "prefect.resource.id": "prefect.worker.kubernetes.k8s-worker",
      "prefect.worker-type": "kubernetes",
      "prefect.resource.name": "k8s-worker",
      "prefect.resource.role": "worker"
    }
  ],
  "resource": {
    "kubernetes.reason": "OOMKilled",
    "prefect.resource.id": "prefect.kubernetes.pod.ce5a56bd-8454-425b-a05a-f222b3ae6a02",
    "kubernetes.namespace": "default",
    "prefect.resource.name": "venomous-tody-95m62-52v96"
  }
}
```
