### PR TITLE
Remove duplicate events code now that 2.10.7 is released

### DIFF
--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -92,13 +92,11 @@ import math
 import os
 import time
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
 
 import anyio.abc
 from prefect.blocks.kubernetes import KubernetesClusterConfig
 from prefect.docker import get_prefect_image_name
-from prefect.events import RelatedResource
-from prefect.events.related import object_as_related_resource, tags_as_related_resources
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
@@ -394,21 +392,6 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
             if not generate_name:
                 generate_name = "prefect-job"
             self.job_manifest["metadata"]["generateName"] = f"{generate_name}-"
-
-    def _related_resources(self) -> List[RelatedResource]:
-        tags = set()
-        related = []
-
-        for kind, obj in self._related_objects.items():
-            # TODO: Remove this method once we've updated the Prefect core side
-            # to ignore objects that are None.
-            if not obj:
-                continue
-            if hasattr(obj, "tags"):
-                tags.update(obj.tags)
-            related.append(object_as_related_resource(kind=kind, role=kind, object=obj))
-
-        return related + tags_as_related_resources(tags)
 
 
 class KubernetesWorkerVariables(BaseVariables):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prefect>=2.10.5
+prefect>=2.10.7
 kubernetes >= 24.2.0


### PR DESCRIPTION
I previously added a modified `_related_resources` function to this library, this PR removes that modified code and bumps the required prefect version now that the modified code exists in Prefect 2.10.7.