### PR TITLE
fix: deployment's k8s client type is `apps` not `core`.

### DIFF
--- a/prefect_kubernetes/deployments.py
+++ b/prefect_kubernetes/deployments.py
@@ -43,10 +43,10 @@ async def create_namespaced_deployment(
             )
         ```
     """
-    with kubernetes_credentials.get_client("core") as core_v1_client:
+    with kubernetes_credentials.get_client("apps") as apps_v1_client:
 
         return await run_sync_in_worker_thread(
-            core_v1_client.create_namespaced_deployment,
+            apps_v1_client.create_namespaced_deployment,
             namespace=namespace,
             body=new_deployment,
             **kube_kwargs,
@@ -91,10 +91,10 @@ async def delete_namespaced_deployment(
             )
         ```
     """
-    with kubernetes_credentials.get_client("core") as core_v1_client:
+    with kubernetes_credentials.get_client("apps") as apps_v1_client:
 
         return await run_sync_in_worker_thread(
-            core_v1_client.delete_namespaced_deployment,
+            apps_v1_client.delete_namespaced_deployment,
             deployment_name,
             body=delete_options,
             namespace=namespace,
@@ -133,10 +133,10 @@ async def list_namespaced_deployment(
             )
         ```
     """
-    with kubernetes_credentials.get_client("core") as core_v1_client:
+    with kubernetes_credentials.get_client("apps") as apps_v1_client:
 
         return await run_sync_in_worker_thread(
-            core_v1_client.list_namespaced_deployment,
+            apps_v1_client.list_namespaced_deployment,
             namespace=namespace,
             **kube_kwargs,
         )
@@ -180,10 +180,10 @@ async def patch_namespaced_deployment(
             )
         ```
     """
-    with kubernetes_credentials.get_client("core") as core_v1_client:
+    with kubernetes_credentials.get_client("apps") as apps_v1_client:
 
         return await run_sync_in_worker_thread(
-            core_v1_client.patch_namespaced_deployment,
+            apps_v1_client.patch_namespaced_deployment,
             name=deployment_name,
             namespace=namespace,
             body=deployment_updates,
@@ -224,10 +224,10 @@ async def read_namespaced_deployment(
             )
         ```
     """
-    with kubernetes_credentials.get_client("core") as core_v1_client:
+    with kubernetes_credentials.get_client("apps") as apps_v1_client:
 
         return await run_sync_in_worker_thread(
-            core_v1_client.read_namespaced_deployment,
+            apps_v1_client.read_namespaced_deployment,
             name=deployment_name,
             namespace=namespace,
             **kube_kwargs,
@@ -272,10 +272,10 @@ async def replace_namespaced_deployment(
             )
         ```
     """
-    with kubernetes_credentials.get_client("core") as core_v1_client:
+    with kubernetes_credentials.get_client("apps") as apps_v1_client:
 
         return await run_sync_in_worker_thread(
-            core_v1_client.replace_namespaced_deployment,
+            apps_v1_client.replace_namespaced_deployment,
             body=new_deployment,
             name=deployment_name,
             namespace=namespace,


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
fix: deployment's k8s client type is `apps` not `core`.

Closes #66

### Example

N/A

### Screenshots

N/A

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
