### PR TITLE
Updates worker metadata to support UI and CLI experiences

### DIFF
--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -459,6 +459,14 @@ class KubernetesWorker(BaseWorker):
     type = "kubernetes"
     job_configuration = KubernetesWorkerJobConfiguration
     job_configuration_variables = KubernetesWorkerVariables
+    _description = (
+        "Execute flow runs within jobs scheduled on a Kubernetes cluster. Requires a "
+        "Kubernetes cluster."
+    )
+    _display_name = "Kubernetes"
+    _documentation_url = "https://prefecthq.github.io/prefect-kubernetes/worker/"
+    _is_beta = True
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/1zrSeY8DZ1MJZs2BAyyyGk/20445025358491b8b72600b8f996125b/Kubernetes_logo_without_workmark.svg.png?h=250"  # noqa
 
     async def run(
         self,


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Updates the metadata fields on the `KubernetesWorker` class. These values are read from the class and stored in the `prefect-collection-registry`, which supports the display of worker type information in the Prefect UI and CLI.

Note: the metadata for this class already matches the values in this PR because the registry was manually updated for this worker. This PR ensures the metadata will persist after the next `prefect-kubernetes` release.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
