### PR TITLE
Fix for `generateName` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.9
+
+Released June 20th, 2023.
+
+### Fixed
+
+- Fixed issue where `generateName` was not populating correctly for some flow runs submitted by `KubernetesWorker` - [#76](https://github.com/PrefectHQ/prefect-kubernetes/pull/76)
+
 ## 0.2.8
 
 Released May 25th, 2023.

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -389,7 +389,16 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
         """Ensures that the generateName is present in the job manifest."""
         manifest_generate_name = self.job_manifest["metadata"].get("generateName", "")
         has_placeholder = len(find_placeholders(manifest_generate_name)) > 0
-        if not manifest_generate_name or has_placeholder:
+        # if name wasn't present during template rendering, generateName will be
+        # just a hyphen
+        manifest_generate_name_templated_with_empty_string = (
+            manifest_generate_name == "-"
+        )
+        if (
+            not manifest_generate_name
+            or has_placeholder
+            or manifest_generate_name_templated_with_empty_string
+        ):
             generate_name = None
             if self.name:
                 generate_name = _slugify_name(self.name)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from contextlib import contextmanager
 from time import monotonic, sleep
 from unittest import mock
@@ -685,7 +686,7 @@ from_template_and_values_cases = [
 class TestKubernetesWorkerJobConfiguration:
     @pytest.fixture
     def flow_run(self):
-        return FlowRun(name="my-flow-run-name")
+        return FlowRun(flow_id=uuid.uuid4(), name="my-flow-run-name")
 
     @pytest.fixture
     def deployment(self):
@@ -918,7 +919,7 @@ class TestKubernetesWorker:
 
     @pytest.fixture
     def flow_run(self):
-        return FlowRun(name="my-flow-run-name")
+        return FlowRun(flow_id=uuid.uuid4(), name="my-flow-run-name")
 
     async def test_creates_job_by_building_a_manifest(
         self,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -155,7 +155,7 @@ from_template_and_values_cases = [
                 "kind": "Job",
                 "metadata": {
                     "namespace": "default",
-                    "generateName": "{{ name }}-",
+                    "generateName": "-",
                     "labels": {},
                 },
                 "spec": {


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Fixes a bug where submitted flow runs crash because `generateName` is not properly populated. If `name` is not present during templating, then the logic to populate a name was not properly fires. This PR fixes that scenario by adding an additional check.

Closes https://github.com/PrefectHQ/prefect/issues/9936

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
