### PR TITLE
Add handling for rescheduled Kubernetes jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Handling for rescheduled Kubernetes job - [#78](https://github.com/PrefectHQ/prefect-kubernetes/pull/78)
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Handling for rescheduled Kubernetes job - [#78](https://github.com/PrefectHQ/prefect-kubernetes/pull/78)
-
 ### Changed
 
 ### Deprecated
@@ -20,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## 0.2.10
+
+Released June 30th, 2023.
+
+### Added
+
+- Handling for rescheduled Kubernetes jobs - [#78](https://github.com/PrefectHQ/prefect-kubernetes/pull/78)
 
 ## 0.2.9
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -148,6 +148,7 @@ def _get_default_job_manifest_template() -> Dict[str, Any]:
             "generateName": "{{ name }}-",
         },
         "spec": {
+            "backoffLimit": 0,
             "ttlSecondsAfterFinished": "{{ finished_job_ttl }}",
             "template": {
                 "spec": {
@@ -843,6 +844,7 @@ class KubernetesWorker(BaseWorker):
             pods = core_client.list_namespaced_pod(
                 namespace=configuration.namespace, label_selector=f"job-name={job_name}"
             )
+            # Get the status for only the most recently used pod
             pods.items.sort(
                 key=lambda pod: pod.metadata.creation_timestamp, reverse=True
             )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2038,6 +2038,41 @@ class TestKubernetesWorker:
 
         assert result.status_code == 137
 
+    async def test_watch_handles_no_pod(
+        self,
+        flow_run,
+        default_configuration,
+        mock_core_client,
+        mock_watch,
+        mock_batch_client,
+    ):
+        # The job should not be completed to start
+        mock_batch_client.read_namespaced_job.return_value.status.completion_time = None
+        mock_core_client.list_namespaced_pod.return_value.items = []
+
+        def mock_stream(*args, **kwargs):
+            if kwargs["func"] == mock_core_client.list_namespaced_pod:
+                job_pod = MagicMock(spec=kubernetes.client.V1Pod)
+                job_pod.status.phase = "Running"
+                yield {"object": job_pod}
+
+            if kwargs["func"] == mock_batch_client.list_namespaced_job:
+                job = MagicMock(spec=kubernetes.client.V1Job)
+
+                # Yield the job then return exiting the stream
+                job.status.completion_time = None
+                job.spec.backoff_limit = 6
+                for i in range(0, 8):
+                    job.status.failed = i
+                    yield {"object": job, "type": "ADDED"}
+
+        mock_watch.stream.side_effect = mock_stream
+
+        async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+            result = await k8s_worker.run(flow_run, default_configuration)
+
+        assert result.status_code == -1
+
     class TestKillInfrastructure:
         async def test_kill_infrastructure_calls_delete_namespaced_job(
             self,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -159,6 +159,7 @@ from_template_and_values_cases = [
                     "labels": {},
                 },
                 "spec": {
+                    "backoffLimit": 0,
                     "template": {
                         "spec": {
                             "parallelism": 1,
@@ -171,7 +172,7 @@ from_template_and_values_cases = [
                                 }
                             ],
                         }
-                    }
+                    },
                 },
             },
             cluster_config=None,
@@ -213,6 +214,7 @@ from_template_and_values_cases = [
                     },
                 },
                 "spec": {
+                    "backoffLimit": 0,
                     "template": {
                         "spec": {
                             "parallelism": 1,
@@ -241,7 +243,7 @@ from_template_and_values_cases = [
                                 }
                             ],
                         }
-                    }
+                    },
                 },
             },
             cluster_config=None,
@@ -290,6 +292,7 @@ from_template_and_values_cases = [
                     "generateName": "test-",
                 },
                 "spec": {
+                    "backoffLimit": 0,
                     "ttlSecondsAfterFinished": 60,
                     "template": {
                         "spec": {
@@ -354,6 +357,7 @@ from_template_and_values_cases = [
                     },
                 },
                 "spec": {
+                    "backoffLimit": 0,
                     "ttlSecondsAfterFinished": 60,
                     "template": {
                         "spec": {


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds handling for rescheduled Kubernetes jobs due to failures such as OOM evictions.

Previously, if a job reached its backoff limit the job would never be marked as completed and the worker would be stuck in a loop of waiting for the job's completion. The loop could only be broken by timeout set on the work pool. 

With these changes, the Kubernetes worker will compare the number of failures of a job to its backoff limit. If the number of job failures exceeds the backoff limit, then the Kubernetes worker will stop watching the job and return the status of the most recently started job pod.

Addresses https://github.com/PrefectHQ/prefect/issues/9647

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

This flow is designed to use 200MB of memory:
```python
from prefect import flow


@flow(log_prints=True)
def cause_oom_eviction():
    x = " " * 1024 * 1024 * 200
    return x
```

Deploying and running this flow in a work pool with the following parameterized job manifest will cause the flow to be evicted due to the configured memory limit of 50MB.
```json
"job_manifest": {
      "kind": "Job",
      "spec": {
        "template": {
          "spec": {
            "containers": [
              {
                "env": "{{ env }}",
                "args": "{{ command }}",
                "name": "prefect-job",
                "image": "{{ image }}",
                "resources": {
                  "limits": {
                    "memory": "50Mi"
                  }
                },
                "imagePullPolicy": "{{ image_pull_policy }}"
              }
            ],
            "completions": 1,
            "parallelism": 1,
            "restartPolicy": "Never",
            "serviceAccountName": "{{ service_account_name }}"
          }
        },
        "ttlSecondsAfterFinished": "{{ finished_job_ttl }}"
      },
      "metadata": {
        "labels": "{{ labels }}",
        "namespace": "{{ namespace }}",
        "generateName": "{{ name }}-"
      },
      "apiVersion": "batch/v1"
    },
```

Error log from the `cause_oom_eviction` flow:
![Screenshot 2023-06-30 at 12 08 26 PM](https://github.com/PrefectHQ/prefect-kubernetes/assets/12350579/bf3f79fd-7964-404c-a58e-0bedcf7f25b0)

The flow is marked as crashed:
![Screenshot 2023-06-30 at 12 25 31 PM](https://github.com/PrefectHQ/prefect-kubernetes/assets/12350579/42b47221-24c8-4973-9b3b-35b58588c96b)

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
