### PR TITLE
When a Job can't schedule a Pod, log the Job's recent events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Log more information when a Pod cannot be scheduled - [#87](https://github.com/PrefectHQ/prefect-kubernetes/issues/87)
+
 ### Added
 
 - Handling for spot instance eviction - [#85](https://github.com/PrefectHQ/prefect-kubernetes/pull/85)
@@ -53,7 +55,7 @@ Released May 25th, 2023.
 - Improve failure message when creating a Kubernetes job fails - [#71](https://github.com/PrefectHQ/prefect-kubernetes/pull/71)
 - Stream Kubernetes Worker flow run logs to the API - [#72](https://github.com/PrefectHQ/prefect-kubernetes/pull/72)
 
-## 0.2.7    
+## 0.2.7
 
 Released May 4th, 2023.
 
@@ -80,7 +82,7 @@ Released April 20th, 2023.
 
 Released April 6th, 2023.
 
-### 
+###
 
 - Temporary `prefect` version guard - [#48](https://github.com/PrefectHQ/prefect-kubernetes/pull/48)
 - Advanced configuration documentation - [#50](https://github.com/PrefectHQ/prefect-kubernetes/pull/50)


### PR DESCRIPTION
In cases where the Job definition itself is fine but the Job is unable to
schedule any Pods due to scheduling constraints (resources, node availability,
etc), we weren't able to give users much more information than that the Pod for
their flow never started.  With this change, we'll go inspect any events related
to that Job and include them in the logs.  These events include things like
scheduling constraint violations, in enough detail to help someone diagnose the
issue without going back to the cluster.

Closes #87

### Screenshots

![image](https://github.com/PrefectHQ/prefect-kubernetes/assets/8194/00a1d6bd-c65d-4409-aa37-2c2ca5f739c9)

![image](https://github.com/PrefectHQ/prefect-kubernetes/assets/8194/1e25f739-9c4c-4d4b-b4f2-7d096b29dd6d)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
