### PR TITLE
Extending the Kubernetes event logging to cover Pod events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Log more information when a Pod cannot be scheduled - [#87](https://github.com/PrefectHQ/prefect-kubernetes/issues/87)
 
+- Log more information when a Pod cannot start - [#90](https://github.com/PrefectHQ/prefect-kubernetes/issues/90)
+
+
 ### Added
 
 - Handling for spot instance eviction - [#85](https://github.com/PrefectHQ/prefect-kubernetes/pull/85)

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -904,7 +904,7 @@ class KubernetesWorker(BaseWorker):
         watch = kubernetes.watch.Watch()
         logger.debug(f"Job {job_name!r}: Starting watch for pod start...")
         last_phase = None
-        last_pod_name: str | None = None
+        last_pod_name: Optional[str] = None
         with self._get_core_client(client) as core_client:
             for event in watch.stream(
                 func=core_client.list_namespaced_pod,
@@ -937,7 +937,7 @@ class KubernetesWorker(BaseWorker):
         self,
         logger: logging.Logger,
         job_name: str,
-        pod_name: str | None,
+        pod_name: Optional[str],
         configuration: KubernetesWorkerJobConfiguration,
         client: "ApiClient",
     ) -> None:


### PR DESCRIPTION
<!-- Overview -->

In #87/#88, we logged additional information from the Kubernetes Event API when
a Job couldn't create a Pod.  In this change, we expand that to log additional
event information when a Pod can't start running.  This covers cases like
`ErrImagePull` or pod scheduling constraint failures that will prevent the Pod
from going into a Running state.

Closes #90

### Example

Example output for an `ErrImagePull`:

```
10:13:41.650 | INFO    | prefect.flow_runs.worker - Worker 'KubernetesWorker 554d9324-689d-4133-ac75-14ff069bd6a8' submitting flow run 'aaa75543-27ca-43cc-bc9b-eb01ff462dfc'
10:13:42.381 | INFO    | prefect.flow_runs.worker - Creating Kubernetes job...
10:13:42.438 | INFO    | prefect.flow_runs.worker - Job 'belligerent-goose-nnkv7': Pod has status 'Pending'.
10:13:42.504 | INFO    | prefect.flow_runs.worker - Completed submission of flow run 'aaa75543-27ca-43cc-bc9b-eb01ff462dfc'
10:13:57.436 | ERROR   | prefect.flow_runs.worker - Job 'belligerent-goose-nnkv7': Pod never started.
10:13:57.611 | INFO    | prefect.flow_runs.worker - Pod event 'Pulling' at 2023-08-29 14:13:42+00:00: Pulling image "chris/busted-image:latest"
10:13:57.612 | INFO    | prefect.flow_runs.worker - Job event 'SuccessfulCreate' at 2023-08-29 14:13:42+00:00: Created pod: belligerent-goose-nnkv7-lf8ts
10:13:57.612 | INFO    | prefect.flow_runs.worker - Pod event 'Scheduled' at 2023-08-29 14:13:42.406297+00:00: Successfully assigned prefect/belligerent-goose-nnkv7-lf8ts to minikube
10:13:57.613 | INFO    | prefect.flow_runs.worker - Pod event 'Failed' at 2023-08-29 14:13:43+00:00: Failed to pull image "chris/busted-image:latest": rpc error: code = Unknown desc = Error response from daemon: pull access denied for chris/busted-image, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
10:13:57.613 | INFO    | prefect.flow_runs.worker - Pod event 'Failed' at 2023-08-29 14:13:43+00:00: Error: ErrImagePull
10:13:57.613 | INFO    | prefect.flow_runs.worker - Pod event 'BackOff' at 2023-08-29 14:13:44+00:00: Back-off pulling image "chris/busted-image:latest"
10:13:57.614 | INFO    | prefect.flow_runs.worker - Pod event 'Failed' at 2023-08-29 14:13:44+00:00: Error: ImagePullBackOff
10:13:57.747 | INFO    | prefect.flow_runs.worker - Reported flow run 'aaa75543-27ca-43cc-bc9b-eb01ff462dfc' as crashed: Flow run infrastructure exited with non-zero status code -1.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
