### PR TITLE
Fixes `env` handling to allow hard coding of environment variable in base job template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Released September 18th, 2023.
 ### Added
 
 - Handling for spot instance eviction - [#85](https://github.com/PrefectHQ/prefect-kubernetes/pull/85)
+- Logging recent job events when pod scheduling fails - [#88](https://github.com/PrefectHQ/prefect-kubernetes/pull/88)
+- Event logging for pod events - [#91](https://github.com/PrefectHQ/prefect-kubernetes/pull/91)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Handling for spot instance eviction - [#85](https://github.com/PrefectHQ/prefect-kubernetes/pull/85)
-
 ### Changed
 
 ### Deprecated
@@ -20,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## 0.2.12
+
+Released September 18th, 2023.
+
+### Added
+
+- Handling for spot instance eviction - [#85](https://github.com/PrefectHQ/prefect-kubernetes/pull/85)
+
+
+### Fixed
+
+- `env` handling to allow hard coding of environment variable in base job template - [#94](https://github.com/PrefectHQ/prefect-kubernetes/pull/94)
 
 ## 0.2.11
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -316,6 +316,17 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
         self._populate_generate_name_if_not_present()
 
     def _populate_env_in_manifest(self):
+        """
+        Populates environment variables in the job manifest.
+
+        When `env` is templated as a variable in the job manifest it comes in as a
+        dictionary. We need to convert it to a list of dictionaries to conform to the
+        Kubernetes job manifest schema.
+
+        This function also handles the case where the user has removed the `{{ env }}`
+        placeholder and hard coded a value for `env`. In this case, we need to prepend
+        our environment variables to the list to ensure Prefect setting propagation.
+        """
         transformed_env = [{"name": k, "value": v} for k, v in self.env.items()]
 
         template_env = self.job_manifest["spec"]["template"]["spec"]["containers"][

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -326,6 +326,8 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
         This function also handles the case where the user has removed the `{{ env }}`
         placeholder and hard coded a value for `env`. In this case, we need to prepend
         our environment variables to the list to ensure Prefect setting propagation.
+        An example reason the a user would remove the `{{ env }}` placeholder to
+        hardcode Kuberentes secrets in the base job template.
         """
         transformed_env = [{"name": k, "value": v} for k, v in self.env.items()]
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -94,7 +94,6 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
 
 import anyio.abc
 from prefect.blocks.kubernetes import KubernetesClusterConfig
-from prefect.docker import get_prefect_image_name
 from prefect.exceptions import (
     InfrastructureError,
     InfrastructureNotAvailable,
@@ -103,6 +102,7 @@ from prefect.exceptions import (
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.dockerutils import get_prefect_image_name
 from prefect.utilities.importtools import lazy_import
 from prefect.utilities.pydantic import JsonPatch
 from prefect.utilities.templating import find_placeholders
@@ -307,15 +307,36 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
         super().prepare_for_flow_run(flow_run, deployment, flow)
         # Update configuration env and job manifest env
         self._update_prefect_api_url_if_local_server()
-        self.job_manifest["spec"]["template"]["spec"]["containers"][0]["env"] = [
-            {"name": k, "value": v} for k, v in self.env.items()
-        ]
+        self._populate_env_in_manifest()
         # Update labels in job manifest
         self._slugify_labels()
         # Add defaults to job manifest if necessary
         self._populate_image_if_not_present()
         self._populate_command_if_not_present()
         self._populate_generate_name_if_not_present()
+
+    def _populate_env_in_manifest(self):
+        transformed_env = [{"name": k, "value": v} for k, v in self.env.items()]
+
+        template_env = self.job_manifest["spec"]["template"]["spec"]["containers"][
+            0
+        ].get("env")
+
+        # If user has removed `{{ env }}` placeholder and hard coded a value for `env`,
+        # we need to prepend our environment variables to the list to ensure Prefect
+        # setting propagation.
+        if isinstance(template_env, list):
+            self.job_manifest["spec"]["template"]["spec"]["containers"][0]["env"] = [
+                *transformed_env,
+                *template_env,
+            ]
+        # Current templating adds `env` as a dict when the kubernetes manifest requires
+        # a list of dicts. Might be able to improve this in the future with a better
+        # default `env` value and better typing.
+        else:
+            self.job_manifest["spec"]["template"]["spec"]["containers"][0][
+                "env"
+            ] = transformed_env
 
     def _update_prefect_api_url_if_local_server(self):
         """If the API URL has been set by the base environment rather than the by the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prefect>=2.10.9
+prefect>=2.13.0
 kubernetes >= 24.2.0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,7 +14,6 @@ import pytest
 from kubernetes.client.exceptions import ApiException
 from kubernetes.config import ConfigException
 from prefect.client.schemas import FlowRun
-from prefect.docker import get_prefect_image_name
 from prefect.exceptions import (
     InfrastructureError,
     InfrastructureNotAvailable,
@@ -28,6 +27,7 @@ from prefect.settings import (
     get_current_settings,
     temporary_settings,
 )
+from prefect.utilities.dockerutils import get_prefect_image_name
 from pydantic import ValidationError
 
 from prefect_kubernetes import KubernetesWorker
@@ -236,6 +236,292 @@ from_template_and_values_cases = [
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
                                             "value": flow_run.id.hex,
+                                        },
+                                    ],
+                                    "image": get_prefect_image_name(),
+                                    "args": ["python", "-m", "prefect.engine"],
+                                }
+                            ],
+                        }
+                    },
+                },
+            },
+            cluster_config=None,
+            job_watch_timeout_seconds=None,
+            pod_watch_timeout_seconds=60,
+            stream_output=True,
+        ),
+    ),
+    (
+        # default base template with custom env
+        {
+            "job_configuration": {
+                "command": "{{ command }}",
+                "env": "{{ env }}",
+                "labels": "{{ labels }}",
+                "name": "{{ name }}",
+                "namespace": "{{ namespace }}",
+                "job_manifest": {
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "metadata": {
+                        "labels": "{{ labels }}",
+                        "namespace": "{{ namespace }}",
+                        "generateName": "{{ name }}-",
+                    },
+                    "spec": {
+                        "backoffLimit": 0,
+                        "ttlSecondsAfterFinished": "{{ finished_job_ttl }}",
+                        "template": {
+                            "spec": {
+                                "parallelism": 1,
+                                "completions": 1,
+                                "restartPolicy": "Never",
+                                "serviceAccountName": "{{ service_account_name }}",
+                                "containers": [
+                                    {
+                                        "name": "prefect-job",
+                                        "env": [
+                                            {
+                                                "name": "TEST_ENV",
+                                                "valueFrom": {
+                                                    "secretKeyRef": {
+                                                        "name": "test-secret",
+                                                        "key": "shhhhh",
+                                                    }
+                                                },
+                                            },
+                                        ],
+                                        "image": "{{ image }}",
+                                        "imagePullPolicy": "{{ image_pull_policy }}",
+                                        "args": "{{ command }}",
+                                    }
+                                ],
+                            }
+                        },
+                    },
+                },
+                "cluster_config": "{{ cluster_config }}",
+                "job_watch_timeout_seconds": "{{ job_watch_timeout_seconds }}",
+                "pod_watch_timeout_seconds": "{{ pod_watch_timeout_seconds }}",
+                "stream_output": "{{ stream_output }}",
+            },
+            "variables": {
+                "description": "Default variables for the Kubernetes worker.\n\nThe schema for this class is used to populate the `variables` section of the default\nbase job template.",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name given to infrastructure created by a worker.",
+                        "type": "string",
+                    },
+                    "env": {
+                        "title": "Environment Variables",
+                        "description": "Environment variables to set when starting a flow run.",
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "labels": {
+                        "title": "Labels",
+                        "description": "Labels applied to infrastructure created by a worker.",
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "command": {
+                        "title": "Command",
+                        "description": "The command to use when starting a flow run. In most cases, this should be left blank and the command will be automatically generated by the worker.",
+                        "type": "string",
+                    },
+                    "namespace": {
+                        "title": "Namespace",
+                        "description": "The Kubernetes namespace to create jobs within.",
+                        "default": "default",
+                        "type": "string",
+                    },
+                    "image": {
+                        "title": "Image",
+                        "description": "The image reference of a container image to use for created jobs. If not set, the latest Prefect image will be used.",
+                        "example": "docker.io/prefecthq/prefect:2-latest",
+                        "type": "string",
+                    },
+                    "service_account_name": {
+                        "title": "Service Account Name",
+                        "description": "The Kubernetes service account to use for job creation.",
+                        "type": "string",
+                    },
+                    "image_pull_policy": {
+                        "title": "Image Pull Policy",
+                        "description": "The Kubernetes image pull policy to use for job containers.",
+                        "default": "IfNotPresent",
+                        "enum": ["IfNotPresent", "Always", "Never"],
+                        "type": "string",
+                    },
+                    "finished_job_ttl": {
+                        "title": "Finished Job TTL",
+                        "description": "The number of seconds to retain jobs after completion. If set, finished jobs will be cleaned up by Kubernetes after the given delay. If not set, jobs will be retained indefinitely.",
+                        "type": "integer",
+                    },
+                    "job_watch_timeout_seconds": {
+                        "title": "Job Watch Timeout Seconds",
+                        "description": "Number of seconds to wait for each event emitted by a job before timing out. If not set, the worker will wait for each event indefinitely.",
+                        "type": "integer",
+                    },
+                    "pod_watch_timeout_seconds": {
+                        "title": "Pod Watch Timeout Seconds",
+                        "description": "Number of seconds to watch for pod creation before timing out.",
+                        "default": 60,
+                        "type": "integer",
+                    },
+                    "stream_output": {
+                        "title": "Stream Output",
+                        "description": "If set, output will be streamed from the job to local standard output.",
+                        "default": True,
+                        "type": "boolean",
+                    },
+                    "cluster_config": {
+                        "title": "Cluster Config",
+                        "description": "The Kubernetes cluster config to use for job creation.",
+                        "allOf": [{"$ref": "#/definitions/KubernetesClusterConfig"}],
+                    },
+                },
+                "definitions": {
+                    "KubernetesClusterConfig": {
+                        "title": "KubernetesClusterConfig",
+                        "description": "Stores configuration for interaction with Kubernetes clusters.\n\nSee `from_file` for creation.",
+                        "type": "object",
+                        "properties": {
+                            "config": {
+                                "title": "Config",
+                                "description": "The entire contents of a kubectl config file.",
+                                "type": "object",
+                            },
+                            "context_name": {
+                                "title": "Context Name",
+                                "description": "The name of the kubectl context to use.",
+                                "type": "string",
+                            },
+                        },
+                        "required": ["config", "context_name"],
+                        "block_type_slug": "kubernetes-cluster-config",
+                        "secret_fields": [],
+                        "block_schema_references": {},
+                    }
+                },
+            },
+        },
+        {},
+        KubernetesWorkerJobConfiguration(
+            command=None,
+            env={},
+            labels={},
+            name=None,
+            namespace="default",
+            job_manifest={
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "metadata": {
+                    "namespace": "default",
+                    "generateName": "-",
+                    "labels": {},
+                },
+                "spec": {
+                    "backoffLimit": 0,
+                    "template": {
+                        "spec": {
+                            "parallelism": 1,
+                            "completions": 1,
+                            "restartPolicy": "Never",
+                            "containers": [
+                                {
+                                    "name": "prefect-job",
+                                    "imagePullPolicy": "IfNotPresent",
+                                    "env": [
+                                        {
+                                            "name": "TEST_ENV",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": "test-secret",
+                                                    "key": "shhhhh",
+                                                }
+                                            },
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    },
+                },
+            },
+            cluster_config=None,
+            job_watch_timeout_seconds=None,
+            pod_watch_timeout_seconds=60,
+            stream_output=True,
+        ),
+        lambda flow_run, deployment, flow: KubernetesWorkerJobConfiguration(
+            command="python -m prefect.engine",
+            env={
+                **get_current_settings().to_environment_variables(exclude_unset=True),
+                "PREFECT__FLOW_RUN_ID": flow_run.id.hex,
+            },
+            labels={
+                "prefect.io/flow-run-id": str(flow_run.id),
+                "prefect.io/flow-run-name": flow_run.name,
+                "prefect.io/version": _slugify_label_value(prefect.__version__),
+                "prefect.io/deployment-id": str(deployment.id),
+                "prefect.io/deployment-name": deployment.name,
+                "prefect.io/flow-id": str(flow.id),
+                "prefect.io/flow-name": flow.name,
+            },
+            name=flow_run.name,
+            namespace="default",
+            job_manifest={
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "metadata": {
+                    "namespace": "default",
+                    "generateName": f"{flow_run.name}-",
+                    "labels": {
+                        "prefect.io/flow-run-id": str(flow_run.id),
+                        "prefect.io/flow-run-name": flow_run.name,
+                        "prefect.io/version": _slugify_label_value(prefect.__version__),
+                        "prefect.io/deployment-id": str(deployment.id),
+                        "prefect.io/deployment-name": deployment.name,
+                        "prefect.io/flow-id": str(flow.id),
+                        "prefect.io/flow-name": flow.name,
+                    },
+                },
+                "spec": {
+                    "backoffLimit": 0,
+                    "template": {
+                        "spec": {
+                            "parallelism": 1,
+                            "completions": 1,
+                            "restartPolicy": "Never",
+                            "containers": [
+                                {
+                                    "name": "prefect-job",
+                                    "imagePullPolicy": "IfNotPresent",
+                                    "env": [
+                                        *[
+                                            {"name": k, "value": v}
+                                            for k, v in get_current_settings()
+                                            .to_environment_variables(
+                                                exclude_unset=True
+                                            )
+                                            .items()
+                                        ],
+                                        {
+                                            "name": "PREFECT__FLOW_RUN_ID",
+                                            "value": flow_run.id.hex,
+                                        },
+                                        {
+                                            "name": "TEST_ENV",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": "test-secret",
+                                                    "key": "shhhhh",
+                                                }
+                                            },
                                         },
                                     ],
                                     "image": get_prefect_image_name(),


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Updates propagation of `env` values into the job manifest generated by the Kubernetes worker to allow hard coding of `env` values in the base job template. With this change, users can add hardcoded environment variables to the base job template to enable the use of Kubernetes secrets like so:
```python
"containers": [
    {
        "name": "prefect-job",
        "env": [
            {
                "name": "TEST_ENV",
                "valueFrom": {
                    "secretKeyRef": {
                        "name": "test-secret",
                        "key": "shhhhh",
                    }
                },
            },
        ],
        "image": "{{ image }}",
        "imagePullPolicy": "{{ image_pull_policy }}",
        "args": "{{ command }}",
    }
],
```
The Kubernetes worker will still handle adding the necessary Prefect setting environment variables to the job manifest, but those values will not override the user hardcoded values.

Closes #83 
Closes https://github.com/PrefectHQ/prefect/issues/10717


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
