### PR TITLE
Updates Kubernetes worker to respect default command from configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           PREFECT_SERVER_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./collection-tests.db"
         run: |
-          coverage run --branch -m pytest tests -vv
+          coverage run --branch -m pytest tests -n auto -vv
           coverage report
 
       - name: Run mkdocs build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,7 @@ jobs:
         env:
           PREFECT_SERVER_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./collection-tests.db"
         run: |
-          coverage run --branch -m pytest tests -n auto -vv
-          coverage report
+          pytest --cov=prefect_kubernetes --no-cov-on-fail --cov-report=term-missing --cov-branch tests -n auto -vv
 
       - name: Run mkdocs build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Log more information when a Pod cannot be scheduled - [#87](https://github.com/PrefectHQ/prefect-kubernetes/issues/87)
-
-- Log more information when a Pod cannot start - [#90](https://github.com/PrefectHQ/prefect-kubernetes/issues/90)
-
-
 ### Added
 
 ### Changed
@@ -23,6 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## 0.3.1
+
+Released October 11th, 2023.
+
+### Changed
+
+- Updated Kubernetes worker to respect default command from base worker configuration - [#97](https://github.com/PrefectHQ/prefect-kubernetes/pull/97)
+
+## 0.3.0
+
+Released October 5th, 2023.
+
+### Added
+
+- Conditional imports to support operating with pydantic>2 installed - [#95](https://github.com/PrefectHQ/prefect-kubernetes/pull/95)
 
 ## 0.2.12
 

--- a/prefect_kubernetes/credentials.py
+++ b/prefect_kubernetes/credentials.py
@@ -45,7 +45,7 @@ class KubernetesCredentials(Block):
     """
 
     _block_type_name = "Kubernetes Credentials"
-    _logo_url = "https://images.ctfassets.net/zscdif0zqppk/oYuHjIbc26oilfQSEMjRv/a61f5f6ef406eead2df5231835b4c4c2/logo.png?h=250"  # noqa
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/2d0b896006ad463b49c28aaac14f31e00e32cfab-250x250.png"  # noqa
     _documentation_url = "https://prefecthq.github.io/prefect-kubernetes/credentials/#prefect_kubernetes.credentials.KubernetesCredentials"  # noqa
 
     cluster_config: Optional[KubernetesClusterConfig] = None

--- a/prefect_kubernetes/jobs.py
+++ b/prefect_kubernetes/jobs.py
@@ -523,7 +523,7 @@ class KubernetesJob(JobBlock):
 
     _block_type_name = "Kubernetes Job"
     _block_type_slug = "k8s-job"
-    _logo_url = "https://images.ctfassets.net/zscdif0zqppk/35vNcprr3MmIlkrKxxCiah/1d720b4b50dfa8876198cf21730cf123/Kubernetes_logo_without_workmark.svg.png?h=250"  # noqa: E501
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/2d0b896006ad463b49c28aaac14f31e00e32cfab-250x250.png"  # noqa: E501
     _documentation_url = "https://prefecthq.github.io/prefect-kubernetes/jobs/#prefect_kubernetes.jobs.KubernetesJob"  # noqa
 
     @sync_compatible

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -515,7 +515,7 @@ class KubernetesWorker(BaseWorker):
     )
     _display_name = "Kubernetes"
     _documentation_url = "https://prefecthq.github.io/prefect-kubernetes/worker/"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/1zrSeY8DZ1MJZs2BAyyyGk/20445025358491b8b72600b8f996125b/Kubernetes_logo_without_workmark.svg.png?h=250"  # noqa
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/2d0b896006ad463b49c28aaac14f31e00e32cfab-250x250.png"  # noqa
 
     async def run(
         self,

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -88,6 +88,7 @@ import enum
 import logging
 import math
 import os
+import shlex
 import time
 from contextlib import contextmanager
 from datetime import datetime
@@ -406,15 +407,11 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
             if command is None:
                 self.job_manifest["spec"]["template"]["spec"]["containers"][0][
                     "args"
-                ] = [
-                    "python",
-                    "-m",
-                    "prefect.engine",
-                ]
+                ] = shlex.split(self._base_flow_run_command())
             elif isinstance(command, str):
                 self.job_manifest["spec"]["template"]["spec"]["containers"][0][
                     "args"
-                ] = command.split()
+                ] = shlex.split(command)
             elif not isinstance(command, list):
                 raise ValueError(
                     "Invalid job manifest template: 'command' must be a string or list."

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,17 @@
-pytest
 black
+coverage
 flake8
 flaky
-mypy
+interrogate
+isort
 mkdocs
+mkdocs-gen-files
 mkdocs-material
 mkdocstrings[python]
-isort
-pre-commit
-pytest-asyncio
 mock; python_version < '3.8'
-mkdocs-gen-files
-interrogate
-coverage
+mypy
 pillow
+pre-commit
+pytest
+pytest-asyncio
+pytest-xdist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,4 +14,5 @@ pillow
 pre-commit
 pytest
 pytest-asyncio
+pytest-cov
 pytest-xdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ fail-under = 95
 omit-covered-files = True
 
 [coverage:run]
-omit = tests/*, prefect_kubernetes/_version.py
+omit = prefect_kubernetes/_version.py
 
 [coverage:report]
 fail_under = 80

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import yaml
 from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api, CustomObjectsApi, models
 from kubernetes.client.exceptions import ApiException
 from prefect.blocks.kubernetes import KubernetesClusterConfig
+from prefect.settings import PREFECT_LOGGING_TO_API_ENABLED, temporary_settings
 from prefect.testing.utilities import prefect_test_harness
 
 from prefect_kubernetes.credentials import KubernetesCredentials
@@ -22,6 +23,15 @@ def prefect_db():
     Sets up test harness for temporary DB during test runs.
     """
     with prefect_test_harness():
+        yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_api_logging():
+    """
+    Disables API logging for all tests.
+    """
+    with temporary_settings(updates={PREFECT_LOGGING_TO_API_ENABLED: False}):
         yield
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -196,7 +196,7 @@ from_template_and_values_cases = [
             command="python -m prefect.engine",
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
-                "PREFECT__FLOW_RUN_ID": flow_run.id.hex,
+                "PREFECT__FLOW_RUN_ID": str(flow_run.id),
             },
             labels={
                 "prefect.io/flow-run-id": str(flow_run.id),
@@ -247,7 +247,7 @@ from_template_and_values_cases = [
                                         ],
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
-                                            "value": flow_run.id.hex,
+                                            "value": str(flow_run.id),
                                         },
                                     ],
                                     "image": get_prefect_image_name(),
@@ -473,7 +473,7 @@ from_template_and_values_cases = [
             command="python -m prefect.engine",
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
-                "PREFECT__FLOW_RUN_ID": flow_run.id.hex,
+                "PREFECT__FLOW_RUN_ID": str(flow_run.id),
             },
             labels={
                 "prefect.io/flow-run-id": str(flow_run.id),
@@ -524,7 +524,7 @@ from_template_and_values_cases = [
                                         ],
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
-                                            "value": flow_run.id.hex,
+                                            "value": str(flow_run.id),
                                         },
                                         {
                                             "name": "TEST_ENV",
@@ -622,7 +622,7 @@ from_template_and_values_cases = [
             command="echo hello",
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
-                "PREFECT__FLOW_RUN_ID": flow_run.id.hex,
+                "PREFECT__FLOW_RUN_ID": str(flow_run.id),
                 "TEST_ENV": "test",
             },
             labels={
@@ -678,7 +678,7 @@ from_template_and_values_cases = [
                                         ],
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
-                                            "value": flow_run.id.hex,
+                                            "value": str(flow_run.id),
                                         },
                                         {
                                             "name": "TEST_ENV",
@@ -900,7 +900,7 @@ from_template_and_values_cases = [
             command="echo hello",
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
-                "PREFECT__FLOW_RUN_ID": flow_run.id.hex,
+                "PREFECT__FLOW_RUN_ID": str(flow_run.id),
                 "TEST_ENV": "test",
             },
             labels={
@@ -953,7 +953,7 @@ from_template_and_values_cases = [
                                         ],
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
-                                            "value": flow_run.id.hex,
+                                            "value": str(flow_run.id),
                                         },
                                         {
                                             "name": "TEST_ENV",


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

This PR make a couple of small updates:
- Updates the default `args` for the job manifest to come from the configuration class instead of being hardcoded
- Add `pytest-xdist` to make tests run faster in CI
- Updates logo URLs

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
