### PR TITLE
Add option to provide Prefect API key to created jobs as a Kubernetes secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.3.2
+
+Released November 7th, 2023.
+
+### Added
+
+- Option to worker to pass Prefect API key to created jobs as a Kubernetes secret - [#99](https://github.com/PrefectHQ/prefect-kubernetes/pull/99)
+
 ## 0.3.1
 
 Released October 11th, 2023.

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -11,75 +11,90 @@ prefect worker start --pool 'my-work-pool' --type kubernetes
 Replace `my-work-pool` with the name of the work pool you want the worker
 to poll for flow runs.
 
-!!! example "Using a custom Kubernetes job manifest template"
-    The default template used for Kubernetes job manifests looks like this:
-    ```yaml
-    ---
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-    labels: "{{ labels }}"
-    namespace: "{{ namespace }}"
-    generateName: "{{ name }}-"
+### Securing your Prefect Cloud API key
+If you are using Prefect Cloud and would like to pass your Prefect Cloud API key to
+created jobs via a Kubernetes secret, set the
+`PREFECT_KUBERNETES_WORKER_STORE_PREFECT_API_IN_SECRET` environment variable before
+starting your worker:
+
+```bash
+export PREFECT_KUBERNETES_WORKER_STORE_PREFECT_API_IN_SECRET="true"
+prefect worker start --pool 'my-work-pool' --type kubernetes
+```
+
+Note that your work will need permission to create secrets in the same namespace(s)
+that Kubernetes jobs are created in to execute flow runs.
+
+### Using a custom Kubernetes job manifest template
+
+The default template used for Kubernetes job manifests looks like this:
+```yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+labels: "{{ labels }}"
+namespace: "{{ namespace }}"
+generateName: "{{ name }}-"
+spec:
+ttlSecondsAfterFinished: "{{ finished_job_ttl }}"
+template:
     spec:
-    ttlSecondsAfterFinished: "{{ finished_job_ttl }}"
-    template:
-        spec:
-        parallelism: 1
-        completions: 1
-        restartPolicy: Never
-        serviceAccountName: "{{ service_account_name }}"
-        containers:
-        - name: prefect-job
-            env: "{{ env }}"
-            image: "{{ image }}"
-            imagePullPolicy: "{{ image_pull_policy }}"
-            args: "{{ command }}"
-    ```
+    parallelism: 1
+    completions: 1
+    restartPolicy: Never
+    serviceAccountName: "{{ service_account_name }}"
+    containers:
+    - name: prefect-job
+        env: "{{ env }}"
+        image: "{{ image }}"
+        imagePullPolicy: "{{ image_pull_policy }}"
+        args: "{{ command }}"
+```
 
-    Each values enclosed in `{{ }}` is a placeholder that will be replaced with
-    a value at runtime. The values that can be used a placeholders are defined
-    by the `variables` schema defined in the base job template.
+Each values enclosed in `{{ }}` is a placeholder that will be replaced with
+a value at runtime. The values that can be used a placeholders are defined
+by the `variables` schema defined in the base job template.
 
-    The default job manifest and available variables can be customized on a work pool
-    by work pool basis. These customizations can be made via the Prefect UI when
-    creating or editing a work pool.
+The default job manifest and available variables can be customized on a work pool
+by work pool basis. These customizations can be made via the Prefect UI when
+creating or editing a work pool.
 
-    For example, if you wanted to allow custom memory requests for a Kubernetes work
-    pool you could update the job manifest template to look like this:
+For example, if you wanted to allow custom memory requests for a Kubernetes work
+pool you could update the job manifest template to look like this:
 
-    ```yaml
-    ---
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-    labels: "{{ labels }}"
-    namespace: "{{ namespace }}"
-    generateName: "{{ name }}-"
+```yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+labels: "{{ labels }}"
+namespace: "{{ namespace }}"
+generateName: "{{ name }}-"
+spec:
+ttlSecondsAfterFinished: "{{ finished_job_ttl }}"
+template:
     spec:
-    ttlSecondsAfterFinished: "{{ finished_job_ttl }}"
-    template:
-        spec:
-        parallelism: 1
-        completions: 1
-        restartPolicy: Never
-        serviceAccountName: "{{ service_account_name }}"
-        containers:
-        - name: prefect-job
-            env: "{{ env }}"
-            image: "{{ image }}"
-            imagePullPolicy: "{{ image_pull_policy }}"
-            args: "{{ command }}"
-            resources:
-                requests:
-                    memory: "{{ memory }}Mi"
-                limits:
-                    memory: 128Mi
-    ```
+    parallelism: 1
+    completions: 1
+    restartPolicy: Never
+    serviceAccountName: "{{ service_account_name }}"
+    containers:
+    - name: prefect-job
+        env: "{{ env }}"
+        image: "{{ image }}"
+        imagePullPolicy: "{{ image_pull_policy }}"
+        args: "{{ command }}"
+        resources:
+            requests:
+                memory: "{{ memory }}Mi"
+            limits:
+                memory: 128Mi
+```
 
-    In this new template, the `memory` placeholder allows customization of the memory
-    allocated to Kubernetes jobs created by workers in this work pool, but the limit
-    is hard-coded and cannot be changed by deployments.
+In this new template, the `memory` placeholder allows customization of the memory
+allocated to Kubernetes jobs created by workers in this work pool, but the limit
+is hard-coded and cannot be changed by deployments.
 
 For more information about work pools and workers,
 checkout out the [Prefect docs](https://docs.prefect.io/concepts/work-pools/).


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds an option to have a worker store its Prefect API key as a Kubernetes secret and provide the secret to created jobs. Prevents the exposure of a worker's Prefect API key by inspecting the manifests of the jobs it creates. The worker will clean up any created secrets upon shutdown.

This feature is opt-in because it requires the worker to have the necessary permissions to create secrets. Once it is battle-tested, this feature will be updates to be the default. 

Closes https://github.com/PrefectHQ/prefect/issues/10716

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
To activate, set the `PREFECT_KUBERNETES_WORKER_STORE_PREFECT_API_IN_SECRET` environment variable:

```bash
$ export PREFECT_KUBERNETES_WORKER_STORE_PREFECT_API_IN_SECRET="true"
```

After running a job, you'll see a new secret created:

```bash
$ kubectl get secrets
kubernetesworker-c7d5551b-e0b9-49b1-a592-65c7-api-key   Opaque   1      96s
```

If you inspect the job, you'll see the same secret used:

```bash
$ kubectl get job papaya-lion-cwl2j -o yaml
apiVersion: batch/v1
kind: Job
spec:
  template:
    spec:
      containers:
      - args:
        - prefect
        - flow-run
        - execute
        env:
        - name: PREFECT_API_URL
          value: https://api.prefect.cloud/api/accounts/a0f10033-f08a-42f8-9b8d-b7a7d4b4b3c1/workspaces/e4b1c666-a4ab-42c7-8172-48d43966e691
        - name: PREFECT_API_KEY
          valueFrom:
            secretKeyRef:
              key: value
              name: kubernetesworker-c7d5551b-e0b9-49b1-a592-65c7-api-key
```

After shutting down the worker, the created secret should be gone:
```bash
$ kubectl get secrets 
No resources found in default namespace.
```
### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
