### PR TITLE
Fix Cluster Autoscaler Evictions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kubernetes Cluster Autoscaler evicting pods on scale down 
+
 ### Security
 
 ## 0.3.2

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -172,9 +172,15 @@ def _get_default_job_manifest_template() -> Dict[str, Any]:
             "generateName": "{{ name }}-",
         },
         "spec": {
-            "backoffLimit": 0,
+            "backoffLimit": "{{ backoff_limit }}",
             "ttlSecondsAfterFinished": "{{ finished_job_ttl }}",
             "template": {
+                "metadata": {
+                    "annotations": {
+                        "cluster-autoscaler.kubernetes.io/"
+                        "safe-to-evict": "{{ safe_to_evict }}"
+                    }
+                },
                 "spec": {
                     "parallelism": 1,
                     "completions": 1,
@@ -189,7 +195,7 @@ def _get_default_job_manifest_template() -> Dict[str, Any]:
                             "args": "{{ command }}",
                         }
                     ],
-                }
+                },
             },
         },
     }
@@ -515,6 +521,20 @@ class KubernetesWorkerVariables(BaseVariables):
     cluster_config: Optional[KubernetesClusterConfig] = Field(
         default=None,
         description="The Kubernetes cluster config to use for job creation.",
+    )
+    safe_to_evict: bool = Field(
+        default=False,
+        description="If set to True and using a Cluster Autoscaler, "
+        "the Pod for a job is allowing rescheduling on a different node. "
+        "Should only be used if your workloads are fault tolerant and you have "
+        "increased the backoff limit. Not doing so will cause the Flow to exhibit "
+        "a Crashed state",
+    )
+    backoff_limit: int = Field(
+        default=0,
+        description="If value is not 0, then the job may recreate the pod without "
+        "failing the kubernetes Job. This will cause a flow to restart from the "
+        "beginning. Should only be used if your workloads are fault tolerant.",
     )
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -181,6 +181,11 @@ from_template_and_values_cases = [
                 "spec": {
                     "backoffLimit": 0,
                     "template": {
+                        "metadata": {
+                            "annotations": {
+                                "cluster-autoscaler.kubernetes.io/safe-to-evict": False
+                            }
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -191,7 +196,7 @@ from_template_and_values_cases = [
                                     "imagePullPolicy": "IfNotPresent",
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },
@@ -236,6 +241,11 @@ from_template_and_values_cases = [
                 "spec": {
                     "backoffLimit": 0,
                     "template": {
+                        "metadata": {
+                            "annotations": {
+                                "cluster-autoscaler.kubernetes.io/safe-to-evict": False
+                            }
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -262,7 +272,7 @@ from_template_and_values_cases = [
                                     "args": ["python", "-m", "prefect.engine"],
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },
@@ -578,6 +588,8 @@ from_template_and_values_cases = [
             "image": "test-image:latest",
             "finished_job_ttl": 60,
             "namespace": "test-namespace",
+            "safe_to_evict": True,
+            "backoff_limit": 6,
         },
         KubernetesWorkerJobConfiguration(
             command="echo hello",
@@ -598,9 +610,14 @@ from_template_and_values_cases = [
                     "generateName": "test-",
                 },
                 "spec": {
-                    "backoffLimit": 0,
+                    "backoffLimit": 6,
                     "ttlSecondsAfterFinished": 60,
                     "template": {
+                        "metadata": {
+                            "annotations": {
+                                "cluster-autoscaler.kubernetes.io/safe-to-evict": True
+                            }
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -617,7 +634,7 @@ from_template_and_values_cases = [
                                     "args": "echo hello",
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },
@@ -663,9 +680,14 @@ from_template_and_values_cases = [
                     },
                 },
                 "spec": {
-                    "backoffLimit": 0,
+                    "backoffLimit": 6,
                     "ttlSecondsAfterFinished": 60,
                     "template": {
+                        "metadata": {
+                            "annotations": {
+                                "cluster-autoscaler.kubernetes.io/safe-to-evict": True
+                            }
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -697,7 +719,7 @@ from_template_and_values_cases = [
                                     "args": ["echo", "hello"],
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },


### PR DESCRIPTION
The Kubernetes Cluster Autoscaler evicts pods on scale-down events based on a [number of criteria](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node). This PR makes the default behavior of new work pools, based on the Kubernetes worker, to prevent eviction. 

The option to disable this setting is added for situations like [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/how-to/extended-duration-pods#limitations) which has a max number of running pods with the required annotation. This also means the backoff limit must be increased to accommodate restarts. Prefect will otherwise mark the Flow as Crashed when the backoff limit is reached. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
