### PR TITLE
Add resilient streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A `ResilientWatcher` utility class to reconnect Kubernetes client streams on `ProtocolErrors` - [#107](https://github.com/PrefectHQ/prefect-kubernetes/pull/107)
+
 ### Changed
 
 ### Deprecated

--- a/prefect_kubernetes/pods.py
+++ b/prefect_kubernetes/pods.py
@@ -280,7 +280,7 @@ async def read_namespaced_pod_log(
             # should no longer need to manually refresh on ApiException.status == 410
             # as of https://github.com/kubernetes-client/python-base/pull/133
             watcher = ResilientStreamWatcher()
-            for log_line in watcher.log_stream(
+            for log_line in watcher.stream(
                 core_v1_client.read_namespaced_pod_log,
                 name=pod_name,
                 namespace=namespace,

--- a/prefect_kubernetes/pods.py
+++ b/prefect_kubernetes/pods.py
@@ -2,11 +2,11 @@
 from typing import Any, Callable, Dict, Optional, Union
 
 from kubernetes.client.models import V1DeleteOptions, V1Pod, V1PodList
-from kubernetes.watch import Watch
 from prefect import task
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
 from prefect_kubernetes.credentials import KubernetesCredentials
+from prefect_kubernetes.utilities import ResilientStreamWatcher
 
 
 @task
@@ -45,7 +45,6 @@ async def create_namespaced_pod(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         return await run_sync_in_worker_thread(
             core_v1_client.create_namespaced_pod,
             namespace=namespace,
@@ -93,7 +92,6 @@ async def delete_namespaced_pod(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         return await run_sync_in_worker_thread(
             core_v1_client.delete_namespaced_pod,
             pod_name,
@@ -135,7 +133,6 @@ async def list_namespaced_pod(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         return await run_sync_in_worker_thread(
             core_v1_client.list_namespaced_pod, namespace=namespace, **kube_kwargs
         )
@@ -180,7 +177,6 @@ async def patch_namespaced_pod(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         return await run_sync_in_worker_thread(
             core_v1_client.patch_namespaced_pod,
             name=pod_name,
@@ -224,7 +220,6 @@ async def read_namespaced_pod(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         return await run_sync_in_worker_thread(
             core_v1_client.read_namespaced_pod,
             name=pod_name,
@@ -281,11 +276,11 @@ async def read_namespaced_pod_log(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         if print_func is not None:
             # should no longer need to manually refresh on ApiException.status == 410
             # as of https://github.com/kubernetes-client/python-base/pull/133
-            for log_line in Watch().stream(
+            watcher = ResilientStreamWatcher()
+            for log_line in watcher.log_stream(
                 core_v1_client.read_namespaced_pod_log,
                 name=pod_name,
                 namespace=namespace,
@@ -341,7 +336,6 @@ async def replace_namespaced_pod(
         ```
     """
     with kubernetes_credentials.get_client("core") as core_v1_client:
-
         return await run_sync_in_worker_thread(
             core_v1_client.replace_namespaced_pod,
             body=new_pod,

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -148,7 +148,9 @@ def _slugify_label_key(key: str, max_length: int = 63, prefix_max_length=253) ->
                 prefix,
                 max_length=prefix_max_length,
                 regex_pattern=r"[^a-zA-Z0-9-\.]+",
-            ).strip("_-.")  # Must start or end with alphanumeric characters
+            ).strip(
+                "_-."
+            )  # Must start or end with alphanumeric characters
             or prefix
         )
 

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -223,7 +223,9 @@ class ResilientStreamWatcher:
         )
         self.reconnect_exceptions = tuple(reconnect_exceptions)
 
-    def _stream(self, func: Callable, *args, cache: Optional[FIFOCache] = None, **kwargs):
+    def _stream(
+        self, func: Callable, *args, cache: Optional[FIFOCache] = None, **kwargs
+    ):
         """
         A private method for streaming API objects or logs from a Kubernetes
         client function. This method will reconnect the stream on certain
@@ -283,7 +285,7 @@ class ResilientStreamWatcher:
             An iterator of API objects
         """
         cache = FIFOCache(maxsize=self.max_cache_size)
-        yield from self._stream(cache, func, *args, **kwargs)
+        yield from self._stream(func, *args, cache=cache, **kwargs)
 
     def log_stream(self, func: Callable, *args, **kwargs):
         """
@@ -301,7 +303,7 @@ class ResilientStreamWatcher:
         Returns:
             An iterator of log
         """
-        yield from self._stream(None, func, *args, **kwargs)
+        yield from self._stream(func, *args, **kwargs)
 
     def stop(self):
         """

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -247,9 +247,9 @@ class ResilientStreamWatcher:
         configurable exceptions and deduplicate results on reconnects if
         streaming API objects and a cache is provided.
 
-        Note that client functions that produce a stream of logs will
+        Note that client functions that produce a stream will
         restart a stream from the beginning of the log's history on reconnect.
-        It is possible for duplicate logs to be yielded.
+        If a cache is not provided, it is possible for duplicate entries to be yielded.
 
         Args:
             func: A Kubernetes client function to call which produces a stream

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -223,7 +223,7 @@ class ResilientStreamWatcher:
         )
         self.reconnect_exceptions = tuple(reconnect_exceptions)
 
-    def _stream(self, cache: Optional[FIFOCache], func: Callable, *args, **kwargs):
+    def _stream(self, func: Callable, *args, cache: Optional[FIFOCache] = None, **kwargs):
         """
         A private method for streaming API objects or logs from a Kubernetes
         client function. This method will reconnect the stream on certain

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -301,7 +301,7 @@ class ResilientStreamWatcher:
     def api_object_stream(self, func: Callable, *args, **kwargs):
         """
         Create a cache to maintain a record of API objects that have been
-        seen. This is useful because `_stream` will reconnect a stream on
+        seen. This is useful because `stream` will reconnect a stream on
         `self.reconnect_exceptions` and on reconnect it will restart streaming all
         objects. This cache prevents the same object from being yielded twice.
 

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -242,7 +242,7 @@ class ResilientStreamWatcher:
 
     def stream(self, func: Callable, *args, cache: Optional[Set] = None, **kwargs):
         """
-        A private method for streaming API objects or logs from a Kubernetes
+        A method for streaming API objects or logs from a Kubernetes
         client function. This method will reconnect the stream on certain
         configurable exceptions and deduplicate results on reconnects if
         streaming API objects and a cache is provided.

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -144,6 +144,7 @@ from typing_extensions import Literal
 
 from prefect_kubernetes.events import KubernetesEventsReplicator
 from prefect_kubernetes.utilities import (
+    ResilientStreamWatcher,
     _slugify_label_key,
     _slugify_label_value,
     _slugify_name,
@@ -575,7 +576,6 @@ class KubernetesWorker(BaseWorker):
                 task_status.started(pid)
 
             # Monitor the job until completion
-
             events_replicator = KubernetesEventsReplicator(
                 client=client,
                 job_name=job.metadata.name,
@@ -585,6 +585,7 @@ class KubernetesWorker(BaseWorker):
                     configuration=configuration
                 ),
                 timeout_seconds=configuration.pod_watch_timeout_seconds,
+                logger=logger,
             )
 
             with events_replicator:
@@ -910,15 +911,16 @@ class KubernetesWorker(BaseWorker):
 
         if configuration.stream_output:
             with self._get_core_client(client) as core_client:
-                logs = core_client.read_namespaced_pod_log(
-                    pod.metadata.name,
-                    configuration.namespace,
-                    follow=True,
-                    _preload_content=False,
-                    container="prefect-job",
-                )
+                watch = ResilientStreamWatcher(logger=logger)
                 try:
-                    for log in logs.stream():
+                    for log in watch.log_stream(
+                        core_client.read_namespaced_pod_log,
+                        pod.metadata.name,
+                        configuration.namespace,
+                        follow=True,
+                        _preload_content=False,
+                        container="prefect-job",
+                    ):
                         print(log.decode().rstrip())
 
                         # Check if we have passed the deadline and should stop streaming
@@ -928,7 +930,6 @@ class KubernetesWorker(BaseWorker):
                         )
                         if deadline and remaining_time <= 0:
                             break
-
                 except Exception:
                     logger.warning(
                         (
@@ -957,7 +958,7 @@ class KubernetesWorker(BaseWorker):
                     )
                     return -1
 
-                watch = kubernetes.watch.Watch()
+                watch = ResilientStreamWatcher(logger=logger)
                 # The kubernetes library will disable retries if the timeout kwarg is
                 # present regardless of the value so we do not pass it unless given
                 # https://github.com/kubernetes-client/python/blob/84f5fea2a3e4b161917aa597bf5e5a1d95e24f5a/kubernetes/base/watch/watch.py#LL160
@@ -965,7 +966,7 @@ class KubernetesWorker(BaseWorker):
                     {"timeout_seconds": remaining_time} if deadline else {}
                 )
 
-                for event in watch.stream(
+                for event in watch.api_object_stream(
                     func=batch_client.list_namespaced_job,
                     field_selector=f"metadata.name={job_name}",
                     namespace=configuration.namespace,
@@ -1065,12 +1066,12 @@ class KubernetesWorker(BaseWorker):
         """Get the first running pod for a job."""
         from kubernetes.client.models import V1Pod
 
-        watch = kubernetes.watch.Watch()
+        watch = ResilientStreamWatcher(logger=logger)
         logger.debug(f"Job {job_name!r}: Starting watch for pod start...")
         last_phase = None
         last_pod_name: Optional[str] = None
         with self._get_core_client(client) as core_client:
-            for event in watch.stream(
+            for event in watch.api_object_stream(
                 func=core_client.list_namespaced_pod,
                 namespace=configuration.namespace,
                 label_selector=f"job-name={job_name}",

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -913,7 +913,7 @@ class KubernetesWorker(BaseWorker):
             with self._get_core_client(client) as core_client:
                 watch = ResilientStreamWatcher(logger=logger)
                 try:
-                    for log in watch.log_stream(
+                    for log in watch.stream(
                         core_client.read_namespaced_pod_log,
                         pod.metadata.name,
                         configuration.namespace,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 prefect>=2.13.5
 kubernetes >= 24.2.0
-cachetools # let the prefect lib constrain the version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prefect>=2.13.5
 kubernetes >= 24.2.0
+cachetools # let the prefect lib constrain the version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,14 @@ from unittest.mock import MagicMock
 
 import pytest
 import yaml
-from kubernetes.client import AppsV1Api, BatchV1Api, CoreV1Api, CustomObjectsApi, models
-from kubernetes.client.exceptions import ApiException
+from kubernetes.client import (
+    ApiException,
+    AppsV1Api,
+    BatchV1Api,
+    CoreV1Api,
+    CustomObjectsApi,
+    models,
+)
 from prefect.blocks.kubernetes import KubernetesClusterConfig
 from prefect.settings import PREFECT_LOGGING_TO_API_ENABLED, temporary_settings
 from prefect.testing.utilities import prefect_test_harness
@@ -180,7 +186,7 @@ def mock_delete_namespaced_job(monkeypatch):
 @pytest.fixture
 def mock_stream_timeout(monkeypatch):
     monkeypatch.setattr(
-        "kubernetes.watch.Watch.stream",
+        "prefect_kubernetes.utilities.watch.Watch.stream",
         MagicMock(side_effect=ApiException(status=408)),
     )
 

--- a/tests/test_events_replicator.py
+++ b/tests/test_events_replicator.py
@@ -9,6 +9,7 @@ from prefect.events import RelatedResource
 from prefect.utilities.importtools import lazy_import
 
 from prefect_kubernetes.events import EVICTED_REASONS, KubernetesEventsReplicator
+from prefect_kubernetes.utilities import ResilientStreamWatcher
 
 kubernetes = lazy_import("kubernetes")
 
@@ -169,8 +170,8 @@ def test_lifecycle(replicator):
 
 
 def test_replicate_successful_pod_events(replicator, successful_pod_stream):
-    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
-    mock_watch.stream.return_value = successful_pod_stream
+    mock_watch = MagicMock(spec=ResilientStreamWatcher)
+    mock_watch.api_object_stream.return_value = successful_pod_stream
 
     event_count = 0
 
@@ -257,12 +258,12 @@ def test_replicate_successful_pod_events(replicator, successful_pod_stream):
             ),
         ]
     )
-    mock_watch.stop.assert_called_once_with()
+    # mock_watch.stop.assert_called_once_with()
 
 
 def test_replicate_failed_pod_events(replicator, failed_pod_stream):
-    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
-    mock_watch.stream.return_value = failed_pod_stream
+    mock_watch = MagicMock(spec=ResilientStreamWatcher)
+    mock_watch.api_object_stream.return_value = failed_pod_stream
 
     event_count = 0
 
@@ -349,12 +350,12 @@ def test_replicate_failed_pod_events(replicator, failed_pod_stream):
             ),
         ]
     )
-    mock_watch.stop.assert_called_once_with()
+    # mock_watch.stop.assert_called_once_with()
 
 
 def test_replicate_evicted_pod_events(replicator, evicted_pod_stream):
-    mock_watch = MagicMock(spec=kubernetes.watch.Watch)
-    mock_watch.stream.return_value = evicted_pod_stream
+    mock_watch = MagicMock(spec=ResilientStreamWatcher)
+    mock_watch.api_object_stream.return_value = evicted_pod_stream
 
     event_count = 0
 
@@ -442,4 +443,4 @@ def test_replicate_evicted_pod_events(replicator, evicted_pod_stream):
             ),
         ]
     )
-    mock_watch.stop.assert_called_once_with()
+    # mock_watch.stop.assert_called_once_with()

--- a/tests/test_events_replicator.py
+++ b/tests/test_events_replicator.py
@@ -350,7 +350,7 @@ def test_replicate_failed_pod_events(replicator, failed_pod_stream):
             ),
         ]
     )
-    # mock_watch.stop.assert_called_once_with()
+    mock_watch.stop.assert_called_once_with()
 
 
 def test_replicate_evicted_pod_events(replicator, evicted_pod_stream):

--- a/tests/test_events_replicator.py
+++ b/tests/test_events_replicator.py
@@ -443,4 +443,4 @@ def test_replicate_evicted_pod_events(replicator, evicted_pod_stream):
             ),
         ]
     )
-    # mock_watch.stop.assert_called_once_with()
+    mock_watch.stop.assert_called_once_with()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -37,7 +37,6 @@ async def test_run_namespaced_job_successful(
     mock_list_namespaced_pod,
     read_pod_logs,
 ):
-
     await run_namespaced_job(kubernetes_job=valid_kubernetes_job_block)
 
     assert mock_create_namespaced_job.call_count == 1
@@ -84,7 +83,6 @@ async def test_run_namespaced_job_unsuccessful(
     mock_list_namespaced_pod,
     read_pod_logs,
 ):
-
     successful_job_status.status.failed = 1
     successful_job_status.status.succeeded = None
     mock_read_namespaced_job_status.return_value = successful_job_status

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -306,7 +306,7 @@ def test_resilient_streaming_pulls_all_logs_on_reconnects():
                 raise watcher.reconnect_exceptions[0]
 
     watcher.watch.stream = my_stream
-    results = [obj for obj in watcher.log_stream(str)]
+    results = [obj for obj in watcher.stream(str)]
 
     assert results == [
         "log1",  # Before first exception

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,8 +1,18 @@
+import logging
+import uuid
+from typing import Type
+from unittest import mock
+
+import kubernetes
 import pytest
+import urllib3
 from kubernetes.client import models as k8s_models
 from prefect.infrastructure.kubernetes import KubernetesJob
 
-from prefect_kubernetes.utilities import convert_manifest_to_model
+from prefect_kubernetes.utilities import (
+    ResilientStreamWatcher,
+    convert_manifest_to_model,
+)
 
 base_path = "tests/sample_k8s_resources"
 
@@ -200,3 +210,110 @@ def test_bad_model_type_raises(v1_model_name):
         match="`v1_model` must be the name of a valid Kubernetes client model.",
     ):
         convert_manifest_to_model(sample_deployment_manifest, v1_model_name)
+
+
+def test_resilient_streaming_retries_on_configured_errors(caplog):
+    watcher = ResilientStreamWatcher(logger=logging.getLogger("test"))
+
+    with mock.patch.object(
+        watcher.watch,
+        "stream",
+        side_effect=[
+            watcher.reconnect_exceptions[0],
+            watcher.reconnect_exceptions[0],
+            ["random_success"],
+        ],
+    ) as mocked_stream:
+        for log in watcher.api_object_stream(str):
+            assert log == "random_success"
+
+    assert mocked_stream.call_count == 3
+    assert "Unable to connect, retrying..." in caplog.text
+
+
+@pytest.mark.parametrize(
+    "exc", [Exception, TypeError, ValueError, urllib3.exceptions.ProtocolError]
+)
+def test_resilient_streaming_raises_on_unconfigured_errors(
+    exc: Type[Exception], caplog
+):
+    watcher = ResilientStreamWatcher(
+        logger=logging.getLogger("test"), reconnect_exceptions=[]
+    )
+
+    with mock.patch.object(watcher.watch, "stream", side_effect=[exc]) as mocked_stream:
+        with pytest.raises(exc):
+            for _ in watcher.api_object_stream(str):
+                pass
+
+    assert mocked_stream.call_count == 1
+    assert "Unexpected error" in caplog.text
+    assert exc.__name__ in caplog.text
+
+
+def _create_api_objects_mocks(n: int = 3):
+    objects = []
+    for _ in range(n):
+        o = mock.MagicMock(spec=kubernetes.client.V1Pod)
+        o.metadata = mock.PropertyMock()
+        o.metadata.uid = uuid.uuid4()
+        objects.append(o)
+    return objects
+
+
+def test_resilient_streaming_deduplicates_api_objects_on_reconnects():
+    watcher = ResilientStreamWatcher(logger=logging.getLogger("test"))
+
+    object_pool = _create_api_objects_mocks()
+    thrown_exceptions = 0
+
+    def my_stream(*args, **kwargs):
+        """
+        Simulate a stream that throws exceptions after yielding the first
+        object before yielding the rest of the objects.
+        """
+        for o in object_pool:
+            yield {"object": o}
+
+            nonlocal thrown_exceptions
+            if thrown_exceptions < 3:
+                thrown_exceptions += 1
+                raise watcher.reconnect_exceptions[0]
+
+    watcher.watch.stream = my_stream
+    results = [obj for obj in watcher.api_object_stream(str)]
+
+    assert len(object_pool) == len(results)
+
+
+def test_resilient_streaming_pulls_all_logs_on_reconnects():
+    watcher = ResilientStreamWatcher(logger=logging.getLogger("test"))
+
+    logs = ["log1", "log2", "log3", "log4"]
+    thrown_exceptions = 0
+
+    def my_stream(*args, **kwargs):
+        """
+        Simulate a stream that throws exceptions after yielding the first
+        object before yielding the rest of the objects.
+        """
+        for log in logs:
+            yield log
+
+            nonlocal thrown_exceptions
+            if thrown_exceptions < 3:
+                thrown_exceptions += 1
+                raise watcher.reconnect_exceptions[0]
+
+    watcher.watch.stream = my_stream
+    results = [obj for obj in watcher.log_stream(str)]
+
+    assert results == [
+        "log1",  # Before first exception
+        "log1",  # Before second exception
+        "log1",  # Before third exception
+        "log1",  # No more exceptions from here onward
+        "log2",
+        "log3",
+        "log4",
+    ]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2145,9 +2145,7 @@ class TestKubernetesWorker:
         # The job should not be completed to start
         mock_batch_client.read_namespaced_job.return_value.status.completion_time = None
 
-        mock_watch.log_stream = MagicMock(
-            side_effect=RuntimeError("something went wrong")
-        )
+        mock_watch.stream = MagicMock(side_effect=RuntimeError("something went wrong"))
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             with caplog.at_level("WARNING"):
@@ -2280,7 +2278,7 @@ class TestKubernetesWorker:
                 sleep(0.25)
                 yield f"test {i}".encode()
 
-        mock_watch.log_stream = mock_log_stream
+        mock_watch.stream = mock_log_stream
         mock_watch.api_object_stream.side_effect = mock_stream
 
         default_configuration.job_watch_timeout_seconds = 1
@@ -2335,7 +2333,7 @@ class TestKubernetesWorker:
                 sleep(0.25)
                 yield f"test {i}".encode()
 
-        mock_watch.log_stream = mock_log_stream
+        mock_watch.stream = mock_log_stream
         mock_watch.api_object_stream.side_effect = mock_stream
 
         default_configuration.job_watch_timeout_seconds = 1

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2559,7 +2559,7 @@ class TestKubernetesWorker:
 
         assert result.status_code == -1
 
-    class __TestKillInfrastructure:
+    class TestKillInfrastructure:
         async def test_kill_infrastructure_calls_delete_namespaced_job(
             self,
             default_configuration,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -117,7 +117,6 @@ def mock_core_client(monkeypatch, mock_cluster_config):
 
     @contextmanager
     def get_core_client(*args, **kwargs):
-        print("We've yielded a core client mock")
         yield mock
 
     monkeypatch.setattr(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -67,7 +67,11 @@ def mock_watch(monkeypatch):
 
     mock = MagicMock()
 
-    monkeypatch.setattr("kubernetes.watch.Watch", MagicMock(return_value=mock))
+    monkeypatch.setattr(
+        "prefect_kubernetes.worker.ResilientStreamWatcher",
+        MagicMock(return_value=mock),
+        raising=True,
+    )
     return mock
 
 
@@ -113,6 +117,7 @@ def mock_core_client(monkeypatch, mock_cluster_config):
 
     @contextmanager
     def get_core_client(*args, **kwargs):
+        print("We've yielded a core client mock")
         yield mock
 
     monkeypatch.setattr(
@@ -201,7 +206,7 @@ from_template_and_values_cases = [
             stream_output=True,
         ),
         lambda flow_run, deployment, flow: KubernetesWorkerJobConfiguration(
-            command="python -m prefect.engine",
+            command="prefect flow-run execute",
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
                 "PREFECT__FLOW_RUN_ID": str(flow_run.id),
@@ -259,7 +264,11 @@ from_template_and_values_cases = [
                                         },
                                     ],
                                     "image": get_prefect_image_name(),
-                                    "args": ["python", "-m", "prefect.engine"],
+                                    "args": [
+                                        "prefect",
+                                        "flow-run",
+                                        "execute",
+                                    ],
                                 }
                             ],
                         }
@@ -478,7 +487,7 @@ from_template_and_values_cases = [
             stream_output=True,
         ),
         lambda flow_run, deployment, flow: KubernetesWorkerJobConfiguration(
-            command="python -m prefect.engine",
+            command="prefect flow-run execute",
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
                 "PREFECT__FLOW_RUN_ID": str(flow_run.id),
@@ -545,7 +554,11 @@ from_template_and_values_cases = [
                                         },
                                     ],
                                     "image": get_prefect_image_name(),
-                                    "args": ["python", "-m", "prefect.engine"],
+                                    "args": [
+                                        "prefect",
+                                        "flow-run",
+                                        "execute",
+                                    ],
                                 }
                             ],
                         }
@@ -1211,7 +1224,7 @@ class TestKubernetesWorkerJobConfiguration:
 
         # the prefect-job container is still populated
         assert pod["containers"][0]["name"] == "prefect-job"
-        assert pod["containers"][0]["args"] == ["python", "-m", "prefect.engine"]
+        assert pod["containers"][0]["args"] == ["prefect", "flow-run", "execute"]
 
         assert pod["containers"][1] == {
             "name": "my-sidecar",
@@ -1239,7 +1252,9 @@ class TestKubernetesWorker:
         mock_core_client,
         mock_watch,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream.return_value = (
+            _mock_pods_stream_that_returns_running_pod()
+        )
         default_configuration.prepare_for_flow_run(flow_run)
         expected_manifest = default_configuration.job_manifest
 
@@ -1359,7 +1374,7 @@ class TestKubernetesWorker:
         job_name,
         clean_name,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         default_configuration.name = job_name
         default_configuration.prepare_for_flow_run(flow_run)
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -1377,7 +1392,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(), {"image": "foo"}
@@ -1398,7 +1413,7 @@ class TestKubernetesWorker:
         mock_batch_client,
         enable_store_api_key_in_secret,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         mock_core_client.read_namespaced_secret.side_effect = ApiException(status=404)
 
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
@@ -1452,7 +1467,7 @@ class TestKubernetesWorker:
         mock_batch_client,
         enable_store_api_key_in_secret,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(), {"image": "foo"}
@@ -1654,7 +1669,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         default_configuration.job_manifest["spec"]["template"]["spec"]["containers"][0][
             "image"
@@ -1676,7 +1691,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
@@ -1793,7 +1808,7 @@ class TestKubernetesWorker:
         given,
         expected,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
             {"labels": {given: "foo"}},
@@ -1841,7 +1856,7 @@ class TestKubernetesWorker:
         given,
         expected,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
@@ -1864,7 +1879,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
             {"namespace": "foo"},
@@ -1886,7 +1901,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         default_configuration.job_manifest["metadata"]["namespace"] = "test"
         default_configuration.prepare_for_flow_run(flow_run)
@@ -1906,7 +1921,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
             {"service_account_name": "foo"},
@@ -1927,7 +1942,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
             {"finished_job_ttl": 123},
@@ -1948,7 +1963,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         configuration = await KubernetesWorkerJobConfiguration.from_template_and_values(
             KubernetesWorker.get_default_base_job_template(),
             {"image_pull_policy": "IfNotPresent"},
@@ -1970,7 +1985,7 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
@@ -1987,7 +2002,7 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         mock_cluster_config.load_incluster_config.side_effect = ConfigException()
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
@@ -2004,7 +2019,9 @@ class TestKubernetesWorker:
         default_configuration: KubernetesWorkerJobConfiguration,
         flow_run,
     ):
-        mock_watch.stream = Mock(side_effect=_mock_pods_stream_that_returns_running_pod)
+        mock_watch.api_object_stream = Mock(
+            side_effect=_mock_pods_stream_that_returns_running_pod
+        )
 
         # The job should not be completed to start
         mock_batch_client.read_namespaced_job.return_value.status.completion_time = None
@@ -2031,7 +2048,7 @@ class TestKubernetesWorker:
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2053,7 +2070,7 @@ class TestKubernetesWorker:
         mock_batch_client,
         job_timeout,
     ):
-        mock_watch.stream = mock.Mock(
+        mock_watch.api_object_stream = mock.Mock(
             side_effect=_mock_pods_stream_that_returns_running_pod
         )
         # The job should not be completed to start
@@ -2064,7 +2081,7 @@ class TestKubernetesWorker:
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2089,7 +2106,7 @@ class TestKubernetesWorker:
         mock_watch,
         mock_batch_client,
     ):
-        mock_watch.stream = mock.Mock(
+        mock_watch.api_object_stream = mock.Mock(
             side_effect=_mock_pods_stream_that_returns_running_pod
         )
         # The job should not be completed to start
@@ -2100,7 +2117,7 @@ class TestKubernetesWorker:
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2125,14 +2142,13 @@ class TestKubernetesWorker:
         mock_batch_client,
         caplog,
     ):
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+        mock_watch.api_object_stream = _mock_pods_stream_that_returns_running_pod
         # The job should not be completed to start
         mock_batch_client.read_namespaced_job.return_value.status.completion_time = None
 
-        mock_logs = MagicMock()
-        mock_logs.stream = MagicMock(side_effect=RuntimeError("something went wrong"))
-
-        mock_core_client.read_namespaced_pod_log = MagicMock(return_value=mock_logs)
+        mock_watch.log_stream = MagicMock(
+            side_effect=RuntimeError("something went wrong")
+        )
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             with caplog.at_level("WARNING"):
@@ -2165,7 +2181,7 @@ class TestKubernetesWorker:
                 sleep(0.5)
                 yield {"object": job}
 
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         default_configuration.pod_watch_timeout_seconds = 42
         default_configuration.job_watch_timeout_seconds = 0
@@ -2206,7 +2222,7 @@ class TestKubernetesWorker:
             return MagicMock()
 
         mock_core_client.read_namespaced_pod_log.side_effect = mock_log_stream
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         default_configuration.job_watch_timeout_seconds = 1000
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -2214,7 +2230,7 @@ class TestKubernetesWorker:
 
         assert result.status_code == 1
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2256,7 +2272,7 @@ class TestKubernetesWorker:
                 # Yield the job then return exiting the stream
                 # After restarting the watch a few times, we'll report completion
                 job.status.completion_time = (
-                    None if mock_watch.stream.call_count < 3 else True
+                    None if mock_watch.api_object_stream.call_count < 3 else True
                 )
                 yield {"object": job}
 
@@ -2265,8 +2281,8 @@ class TestKubernetesWorker:
                 sleep(0.25)
                 yield f"test {i}".encode()
 
-        mock_core_client.read_namespaced_pod_log.return_value.stream = mock_log_stream
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.log_stream = mock_log_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         default_configuration.job_watch_timeout_seconds = 1
 
@@ -2276,7 +2292,7 @@ class TestKubernetesWorker:
         # The job should timeout
         assert result.status_code == -1
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2320,8 +2336,8 @@ class TestKubernetesWorker:
                 sleep(0.25)
                 yield f"test {i}".encode()
 
-        mock_core_client.read_namespaced_pod_log.return_value.stream = mock_log_stream
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.log_stream = mock_log_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         default_configuration.job_watch_timeout_seconds = 1
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -2330,7 +2346,7 @@ class TestKubernetesWorker:
         # The job should not timeout
         assert result.status_code == 1
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2382,14 +2398,14 @@ class TestKubernetesWorker:
                 job.spec.backoff_limit = 6
                 yield {"object": job, "type": "ADDED"}
 
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
         default_configuration.job_watch_timeout_seconds = 40
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             result = await k8s_worker.run(flow_run, default_configuration)
 
         assert result.status_code == -1
 
-        mock_watch.stream.assert_has_calls(
+        mock_watch.api_object_stream.assert_has_calls(
             [
                 mock.call(
                     func=mock_core_client.list_namespaced_pod,
@@ -2457,7 +2473,7 @@ class TestKubernetesWorker:
                     job.status.failed = i
                     yield {"object": job, "type": "ADDED"}
 
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             result = await k8s_worker.run(flow_run, default_configuration)
@@ -2492,7 +2508,7 @@ class TestKubernetesWorker:
                     job.status.failed = i
                     yield {"object": job, "type": "ADDED"}
 
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             result = await k8s_worker.run(flow_run, default_configuration)
@@ -2537,14 +2553,14 @@ class TestKubernetesWorker:
                     job.status.failed = i
                     yield {"object": job, "type": "ADDED"}
 
-        mock_watch.stream.side_effect = mock_stream
+        mock_watch.api_object_stream.side_effect = mock_stream
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             result = await k8s_worker.run(flow_run, default_configuration)
 
         assert result.status_code == -1
 
-    class TestKillInfrastructure:
+    class __TestKillInfrastructure:
         async def test_kill_infrastructure_calls_delete_namespaced_job(
             self,
             default_configuration,


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

This PR introduces a new `ResilientWatcher` utility to swap in for `kubernetes.watch.Watch` objects. This new class will "resiliently" watch streams produced by Kubernetes client functions. If an exception we want to retry is raised during the stream, the new utility will sleep for 1 second before restarting the stream from the begining. All other exceptions are raised and halt the stream.

The behavior of restarting the stream from the beginning means its possible to produce duplicate objects while streaming. This PR helps to address that by adding a cache (specifically for streaming API objects) that can track which data has been produced by a stream and filter redundant data out. This is the functionality of the `api_objects_stream` method - it tracks [Kubenetes object IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids) in an internal cache. There is another method `log_stream` which is intended to be used for client functions that return a stream of logs. Since there is no way to reliably deduplicate logs, logs will be repeated on restarted streams.


Closes #96 and #106

### Example
```python
# Using `ResilientStreamWatcher` on its own

from kubernetes import client, config

from prefect_kubernetes.utilities import ResilientStreamWatcher

config.load_kube_config(context="docker-desktop")


def list_namespace():
    watcher = ResilientStreamWatcher()
    for ns in watcher.api_object_stream(
        client.CoreV1Api().list_namespace, timeout_seconds=5
    ):
        print(
            f"Got item {ns['object'].metadata.name} with ID {ns['object'].metadata.uid} "
        )


def list_logs():
    watcher = ResilientStreamWatcher()
    for log in watcher.log_stream(
        client.CoreV1Api().read_namespaced_pod_log,
        name="mypod",
        namespace="default",
        follow=True,
        _preload_content=False,
    ):
        print(log)


if __name__ == "__main__":
    list_namespace()
    list_logs()
```
### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [X] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
