### PR TITLE
Add TCP keepalive to `KubernetesWorker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A `ResilientWatcher` utility class to reconnect Kubernetes client streams on `ProtocolErrors` - [#107](https://github.com/PrefectHQ/prefect-kubernetes/pull/107)
+- TCP keepalive option for preventing closure of inactive connections - [#108](https://github.com/PrefectHQ/prefect-kubernetes/pull/108)
 
 ### Changed
 
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## 0.3.3
+
+Released January 23rd, 2024.
+
+### Added
+
+- A `ResilientWatcher` utility class to reconnect Kubernetes client streams on `ProtocolErrors` - [#107](https://github.com/PrefectHQ/prefect-kubernetes/pull/107)
 
 ## 0.3.2
 
@@ -55,7 +63,6 @@ Released September 18th, 2023.
 - Logging recent job events when pod scheduling fails - [#88](https://github.com/PrefectHQ/prefect-kubernetes/pull/88)
 - Event logging for pod events - [#91](https://github.com/PrefectHQ/prefect-kubernetes/pull/91)
 
-
 ### Fixed
 
 - `env` handling to allow hard coding of environment variable in base job template - [#94](https://github.com/PrefectHQ/prefect-kubernetes/pull/94)
@@ -65,6 +72,7 @@ Released September 18th, 2023.
 Released July 20th, 2023.
 
 ### Changed
+
 - Promoted workers to GA, removed beta disclaimers
 
 ## 0.2.10
@@ -99,6 +107,7 @@ Released May 4th, 2023.
 ### Added
 
 - Fixed issue where `KubernetesEventReplicator` would not shutdown after a flow-run was completed resulting in new flow-runs not being picked up and the worker hanging on exit. - [#57](https://github.com/PrefectHQ/prefect-kubernetes/pull/57)
+
 ## 0.2.6
 
 Released April 28th, 2023.
@@ -113,7 +122,7 @@ Released April 20th, 2023.
 
 ### Added
 
-- `kill_infrastructure` method on `KubernetesWorker` which stops jobs for cancelled flow runs  - [#52](https://github.com/PrefectHQ/prefect-kubernetes/pull/52)
+- `kill_infrastructure` method on `KubernetesWorker` which stops jobs for cancelled flow runs - [#52](https://github.com/PrefectHQ/prefect-kubernetes/pull/52)
 
 ## 0.2.4
 
@@ -149,6 +158,7 @@ Released March 24, 2023.
 Released February 17, 2023.
 
 ### Added
+
 - Sync compatibility for block method calls used by `run_namespaced_job` - [#34](https://github.com/PrefectHQ/prefect-kubernetes/pull/34)
 
 ## 0.2.0
@@ -156,6 +166,7 @@ Released February 17, 2023.
 Released December 23, 2022.
 
 ### Added
+
 - `KubernetesJob` block for running a Kubernetes job from a manifest - [#28](https://github.com/PrefectHQ/prefect-kubernetes/pull/28)
 - `run_namespaced_job` flow allowing easy execution of a well-specified `KubernetesJob` block on a cluster specified by `KubernetesCredentials` - [#28](https://github.com/PrefectHQ/prefect-kubernetes/pull/28)
 - `convert_manifest_to_model` utility function for converting a Kubernetes manifest to a model object - [#28](https://github.com/PrefectHQ/prefect-kubernetes/pull/28)
@@ -163,7 +174,9 @@ Released December 23, 2022.
 ## 0.1.0
 
 Released November 21, 2022.
+
 ### Added
+
 - `KubernetesCredentials` block for generating authenticated Kubernetes clients - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/19)
 - Tasks for interacting with `job` resources: `create_namespaced_job`, `delete_namespaced_job`, `list_namespaced_job`, `patch_namespaced_job`, `read_namespaced_job`, `replace_namespaced_job` - [#19](https://github.com/PrefectHQ/prefect-kubernetes/pull/19)
 - Tasks for interacting with `pod` resources: `create_namespaced_pod`, `delete_namespaced_pod`, `list_namespaced_pod`, `patch_namespaced_pod`, `read_namespaced_pod`, `read_namespaced_pod_logs`, `replace_namespaced_pod` - [#21](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)
@@ -173,4 +186,5 @@ Released November 21, 2022.
 - Tasks for interacting with `deployment` resources: `create_namespaced_deployment`, `delete_namespaced_deployment`, `list_namespaced_deployment`, `patch_namespaced_deployment`, `read_namespaced_deployment`, `replace_namespaced_deployment` - [#25](https://github.com/PrefectHQ/prefect-kubernetes/pull/25)
 
 ### Changed
+
 - `KubernetesCredentials` block to use a single `get_client` method capable of creating all resource-specific client types - [#21](https://github.com/PrefectHQ/prefect-kubernetes/pull/21)

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -3,10 +3,11 @@ import logging
 import time
 from pathlib import Path
 from typing import Callable, List, Optional, Set, Type, TypeVar, Union
+import sys
 
 import urllib3
 from kubernetes import watch
-from kubernetes.client import models as k8s_models
+from kubernetes.client import models as k8s_models, ApiClient
 from prefect.infrastructure.kubernetes import KubernetesJob, KubernetesManifest
 from slugify import slugify
 
@@ -33,6 +34,41 @@ class _CappedSet(set):
         if len(self) >= self.maxsize:
             self.pop()
         super().add(value)
+
+
+def enable_socket_keep_alive(client: ApiClient) -> None:
+    """
+    Setting the keep-alive flags on the kubernetes client object.
+    Unfortunately neither the kubernetes library nor the urllib3 library which kubernetes is using
+    internally offer the functionality to enable keep-alive messages. Thus the flags are added to
+    be used on the underlying sockets.
+
+    Args:
+        - client (KubernetesClient): the kubernetes client object on which the keep-alive should be
+            enabled
+    """
+    import socket
+
+    socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        socket_options.append((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30))
+
+    if hasattr(socket, "TCP_KEEPCNT"):
+        socket_options.append((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6))
+
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        socket_options.append((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 6))
+
+    if sys.platform == "darwin":
+        # TCP_KEEP_ALIVE not available on socket module in macOS, but defined in
+        # https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/netinet/tcp.h#L215
+        TCP_KEEP_ALIVE = 0x10
+        socket_options.append((socket.IPPROTO_TCP, TCP_KEEP_ALIVE, 30))
+
+    client.rest_client.pool_manager.connection_pool_kw[
+        "socket_options"
+    ] = socket_options
 
 
 def convert_manifest_to_model(

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -1,5 +1,6 @@
 """ Utilities for working with the Python Kubernetes API. """
 import logging
+import socket
 import sys
 import time
 from pathlib import Path
@@ -44,7 +45,6 @@ def enable_socket_keep_alive(client: ApiClient) -> None:
     kubernetes is using internally offer the functionality to enable keep-alive
     messages. Thus the flags are added to be used on the underlying sockets.
     """
-    import socket
 
     socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
 

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -1,13 +1,14 @@
 """ Utilities for working with the Python Kubernetes API. """
 import logging
+import sys
 import time
 from pathlib import Path
 from typing import Callable, List, Optional, Set, Type, TypeVar, Union
-import sys
 
 import urllib3
 from kubernetes import watch
-from kubernetes.client import models as k8s_models, ApiClient
+from kubernetes.client import ApiClient
+from kubernetes.client import models as k8s_models
 from prefect.infrastructure.kubernetes import KubernetesJob, KubernetesManifest
 from slugify import slugify
 
@@ -39,13 +40,9 @@ class _CappedSet(set):
 def enable_socket_keep_alive(client: ApiClient) -> None:
     """
     Setting the keep-alive flags on the kubernetes client object.
-    Unfortunately neither the kubernetes library nor the urllib3 library which kubernetes is using
-    internally offer the functionality to enable keep-alive messages. Thus the flags are added to
-    be used on the underlying sockets.
-
-    Args:
-        - client (KubernetesClient): the kubernetes client object on which the keep-alive should be
-            enabled
+    Unfortunately neither the kubernetes library nor the urllib3 library which
+    kubernetes is using internally offer the functionality to enable keep-alive
+    messages. Thus the flags are added to be used on the underlying sockets.
     """
     import socket
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -523,9 +523,9 @@ class KubernetesWorkerVariables(BaseVariables):
     tcp_keepalive: bool = Field(
         default=True,
         description=(
-            "Maintain connections to the Kubernetes API by sending ",
-            "keep-alive messages. Recommended when using cloud load ",
-            "balancers or firewalls.",
+            "Maintain connections to the Kubernetes API by sending "
+            "keep-alive messages. Recommended when using cloud load "
+            "balancers or firewalls."
         ),
     )
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -259,7 +259,6 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
     job_watch_timeout_seconds: Optional[int] = Field(default=None)
     pod_watch_timeout_seconds: int = Field(default=60)
     stream_output: bool = Field(default=True)
-    tcp_keepalive: bool = Field(default=True)
 
     # internal-use only
     _api_dns_name: Optional[str] = None  # Replaces 'localhost' in API URL
@@ -519,14 +518,6 @@ class KubernetesWorkerVariables(BaseVariables):
         default=None,
         description="The Kubernetes cluster config to use for job creation.",
     )
-    tcp_keepalive: bool = Field(
-        default=True,
-        description=(
-            "Maintain connections to the Kubernetes API by sending "
-            "keep-alive messages. Recommended when using cloud load "
-            "balancers or firewalls."
-        ),
-    )
 
 
 class KubernetesWorkerResult(BaseWorkerResult):
@@ -716,7 +707,7 @@ class KubernetesWorker(BaseWorker):
             except kubernetes.config.ConfigException:
                 client = kubernetes.config.new_client_from_config()
 
-        if configuration.tcp_keepalive:
+        if os.environ.get("TCP_KEEPALIVE", "").strip().lower() in ("true", "1"):
             enable_socket_keep_alive(client)
 
         return client

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -708,7 +708,7 @@ class KubernetesWorker(BaseWorker):
                 client = kubernetes.config.new_client_from_config()
 
         if os.environ.get(
-            "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", ""
+            "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", "TRUE"
         ).strip().lower() in ("true", "1"):
             enable_socket_keep_alive(client)
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -707,7 +707,9 @@ class KubernetesWorker(BaseWorker):
             except kubernetes.config.ConfigException:
                 client = kubernetes.config.new_client_from_config()
 
-        if os.environ.get("TCP_KEEPALIVE", "").strip().lower() in ("true", "1"):
+        if os.environ.get(
+            "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", ""
+        ).strip().lower() in ("true", "1"):
             enable_socket_keep_alive(client)
 
         return client

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -110,7 +110,6 @@ import time
 from contextlib import contextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
-import sys
 
 import anyio.abc
 from kubernetes.client.exceptions import ApiException

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,6 +1,4 @@
 import logging
-import socket
-import sys
 import uuid
 from typing import Type
 from unittest import mock

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,18 +1,25 @@
 import logging
+import socket
+import sys
 import uuid
 from typing import Type
 from unittest import mock
+from unittest.mock import MagicMock
 
 import kubernetes
 import pytest
 import urllib3
 from kubernetes.client import models as k8s_models
+from kubernetes.config import ConfigException
 from prefect.infrastructure.kubernetes import KubernetesJob
 
 from prefect_kubernetes.utilities import (
     ResilientStreamWatcher,
     convert_manifest_to_model,
+    enable_socket_keep_alive,
 )
+
+FAKE_CLUSTER = "fake-cluster"
 
 base_path = "tests/sample_k8s_resources"
 
@@ -163,6 +170,25 @@ expected_service_model = k8s_models.V1Service(
         ),
     )
 )
+
+
+@pytest.fixture
+def mock_cluster_config(monkeypatch):
+    mock = MagicMock()
+    # We cannot mock this or the `except` clause will complain
+    mock.config.ConfigException = ConfigException
+    mock.list_kube_config_contexts.return_value = (
+        [],
+        {"context": {"cluster": FAKE_CLUSTER}},
+    )
+    monkeypatch.setattr("kubernetes.config", mock)
+    monkeypatch.setattr("kubernetes.config.ConfigException", ConfigException)
+    return mock
+
+
+@pytest.fixture
+def mock_api_client(mock_cluster_config):
+    return MagicMock()
 
 
 @pytest.mark.parametrize(
@@ -317,3 +343,14 @@ def test_resilient_streaming_pulls_all_logs_on_reconnects():
         "log3",
         "log4",
     ]
+
+
+def test_keep_alive_updates_socket_options(mock_api_client):
+    enable_socket_keep_alive(mock_api_client)
+
+    assert (
+        mock_api_client.rest_client.pool_manager.connection_pool_kw[
+            "socket_options"
+        ]._mock_set_call
+        is not None
+    )


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds an option to the Kubernetes Worker to enable TCP keepalive during job runs to maintain connections when the pod is silent.  This is especially useful on AKS, where the default load balancer policy drops inactive connections after 4 minutes.

Closes #106

Long-running sleepy flow on AKS when the setting is off:
```
Worker 'KubernetesWorker 59f3812c-7ee0-4e51-94ff-edaa3702c14c' submitting flow run 'd6727728-10b5-4305-997d-f4d9d5630ceb'
05:20:53 PM
prefect.flow_runs.worker
Creating Kubernetes job...
05:20:54 PM
prefect.flow_runs.worker
Job 'omicron503-sobras-rph7h': Pod has status 'Pending'.
05:20:54 PM
prefect.flow_runs.worker
Completed submission of flow run 'd6727728-10b5-4305-997d-f4d9d5630ceb'
05:20:54 PM
prefect.flow_runs.worker
Opening process...
05:20:56 PM
prefect.flow_runs.runner
sleeping for 1200
05:20:58 PM
prefect.flow_runs
Unable to connect, retrying...
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/urllib3/response.py", line 712, in _error_catcher
    yield
  File "/usr/local/lib/python3.11/site-packages/urllib3/response.py", line 1071, in read_chunked
    self._update_chunk_length()
  File "/usr/local/lib/python3.11/site-packages/urllib3/response.py", line 1006, in _update_chunk_length
    raise InvalidChunkLength(self, line) from None
urllib3.exceptions.InvalidChunkLength: InvalidChunkLength(got length b'', 0 bytes read)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/prefect/prefect_kubernetes/utilities.py", line 304, in stream
    for event in self.watch.stream(func, *args, **kwargs):
  File "/usr/local/lib/python3.11/site-packages/kubernetes/watch/watch.py", line 178, in stream
    for line in iter_resp_lines(resp):
  File "/usr/local/lib/python3.11/site-packages/kubernetes/watch/watch.py", line 56, in iter_resp_lines
    for segment in resp.stream(amt=None, decode_content=False):
  File "/usr/local/lib/python3.11/site-packages/urllib3/response.py", line 931, in stream
    yield from self.read_chunked(amt, decode_content=decode_content)
  File "/usr/local/lib/python3.11/site-packages/urllib3/response.py", line 1059, in read_chunked
    with self._error_catcher():
  File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.11/site-packages/urllib3/response.py", line 729, in _error_catcher
    raise ProtocolError(f"Connection broken: {e!r}", e) from e
urllib3.exceptions.ProtocolError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))
```

and when the setting is on:

```
Worker 'KubernetesWorker 329e9221-8de5-49f3-85e3-079f489e911a' submitting flow run 'b63c4508-a681-411d-8b07-271670347ddc'
11:16:43 AM
prefect.flow_runs.worker
11:16:43 AM
prefect.flow_runs.worker
Creating Kubernetes job...
11:16:43 AM
prefect.flow_runs.worker
Completed submission of flow run 'b63c4508-a681-411d-8b07-271670347ddc'
11:16:43 AM
prefect.flow_runs.worker
Job 'rho-folde-shift-sjj7f': Pod has status 'Pending'.
11:16:43 AM
prefect.flow_runs.worker
Opening process...
11:16:45 AM
prefect.flow_runs.runner
sleeping for 1200
11:16:47 AM
prefect.flow_runs
Finished in state Completed()
11:36:48 AM
prefect.flow_runs
Process for flow run 'rho-folde-shift' exited cleanly.
11:36:48 AM
prefect.flow_runs.runner
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
