### PR TITLE
Cache Kubernetes `ApiClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reverting [#107](https://github.com/PrefectHQ/prefect-kubernetes/pull/107) to address 
-deadlocking issue.
+- Added Kubernetes client caching to prevent worker from running out of sockets - [#111](https://github.com/PrefectHQ/prefect-kubernetes/pull/111)
+
+- Reverting [#107](https://github.com/PrefectHQ/prefect-kubernetes/pull/107) to address
+  deadlocking issue.
 
 ### Security
 

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -8,7 +8,6 @@ from typing import Optional, TypeVar, Union
 from kubernetes.client import ApiClient
 from kubernetes.client import models as k8s_models
 from prefect.infrastructure.kubernetes import KubernetesJob, KubernetesManifest
-from prefect.utilities.collections import visit_collection
 from slugify import slugify
 
 # Note: `dict(str, str)` is the Kubernetes API convention for
@@ -46,38 +45,6 @@ def enable_socket_keep_alive(client: ApiClient) -> None:
     client.rest_client.pool_manager.connection_pool_kw[
         "socket_options"
     ] = socket_options
-
-
-def hash_collection(collection) -> int:
-    """Use visit_collection to transform and hash a collection.
-
-    Args:
-        collection (Any): The collection to hash.
-
-    Returns:
-        int: The hash of the transformed collection.
-
-    Example:
-        ```python
-        from prefect_kubernetes.utilities import hash_collection
-
-        hash_collection({"a": 1, "b": 2})
-        ```
-
-    """
-
-    def make_hashable(item):
-        """Make an item hashable by converting it to a tuple."""
-        if isinstance(item, dict):
-            return tuple(sorted((k, make_hashable(v)) for k, v in item.items()))
-        elif isinstance(item, list):
-            return tuple(make_hashable(v) for v in item)
-        return item
-
-    hashable_collection = visit_collection(
-        collection, visit_fn=make_hashable, return_data=True
-    )
-    return hash(hashable_collection)
 
 
 def convert_manifest_to_model(

--- a/prefect_kubernetes/utilities.py
+++ b/prefect_kubernetes/utilities.py
@@ -59,7 +59,7 @@ def hash_collection(collection) -> int:
 
     Example:
         ```python
-        from prefect_aws.utilities import hash_collection
+        from prefect_kubernetes.utilities import hash_collection
 
         hash_collection({"a": 1, "b": 2})
         ```

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -99,6 +99,7 @@ is hard-coded and cannot be changed by deployments.
 For more information about work pools and workers,
 checkout out the [Prefect docs](https://docs.prefect.io/concepts/work-pools/).
 """
+
 import asyncio
 import base64
 import enum
@@ -109,6 +110,8 @@ import shlex
 import time
 from contextlib import contextmanager
 from datetime import datetime
+from functools import lru_cache
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
 
 import anyio.abc
@@ -134,6 +137,7 @@ from prefect.workers.base import (
     BaseWorkerResult,
 )
 from pydantic import VERSION as PYDANTIC_VERSION
+from pydantic import BaseModel
 
 if PYDANTIC_VERSION.startswith("2."):
     from pydantic.v1 import Field, validator
@@ -148,6 +152,7 @@ from prefect_kubernetes.utilities import (
     _slugify_label_value,
     _slugify_name,
     enable_socket_keep_alive,
+    hash_collection,
 )
 
 if TYPE_CHECKING:
@@ -160,6 +165,59 @@ if TYPE_CHECKING:
     from prefect.client.schemas import FlowRun
 else:
     kubernetes = lazy_import("kubernetes")
+
+_LOCK = Lock()
+
+
+class HashableKubernetesClusterConfig(BaseModel):
+    """
+    A hashable version of the KubernetesClusterConfig class.
+    Used for caching.
+    """
+
+    config: Optional[dict[str, Any]] = Field(...)
+    context_name: str = Field(...)
+
+    def __hash__(self):
+        """Make the conifg hashable."""
+        return hash(
+            (
+                hash_collection(self.config),
+                self.context_name,
+            )
+        )
+
+
+@lru_cache(maxsize=8, typed=True)
+def _get_cached_kubernetes_client(
+    cluster_config: Optional[HashableKubernetesClusterConfig] = None,
+) -> Any:
+    "Returns a new Kubernetes client is there is not one cached"
+    with _LOCK:
+        # if a hard-coded cluster config is provided, use it
+        if cluster_config:
+            client = kubernetes.config.new_client_from_config_dict(
+                config_dict=cluster_config.config,
+                context=cluster_config.context_name,
+            )
+        else:
+            # If no hard-coded config specified, try to load Kubernetes configuration
+            # within a cluster. If that doesn't work, try to load the configuration
+            # from the local environment, allowing any further ConfigExceptions to
+            # bubble up.
+            try:
+                kubernetes.config.load_incluster_config()
+                config = kubernetes.client.Configuration.get_default_copy()
+                client = kubernetes.client.ApiClient(configuration=config)
+            except kubernetes.config.ConfigException:
+                client = kubernetes.config.new_client_from_config()
+
+        if os.environ.get(
+            "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", "TRUE"
+        ).strip().lower() in ("true", "1"):
+            enable_socket_keep_alive(client)
+
+        return client
 
 
 def _get_default_job_manifest_template() -> Dict[str, Any]:
@@ -688,30 +746,15 @@ class KubernetesWorker(BaseWorker):
         Returns a configured Kubernetes client.
         """
 
-        # if a hard-coded cluster config is provided, use it
+        cluster_config = None
+
         if configuration.cluster_config:
-            client = kubernetes.config.new_client_from_config_dict(
-                config_dict=configuration.cluster_config.config,
-                context=configuration.cluster_config.context_name,
+            cluster_config = HashableKubernetesClusterConfig(
+                config=configuration.cluster_config.config,
+                context_name=configuration.cluster_config.context_name,
             )
-        else:
-            # If no hard-coded config specified, try to load Kubernetes configuration
-            # within a cluster. If that doesn't work, try to load the configuration
-            # from the local environment, allowing any further ConfigExceptions to
-            # bubble up.
-            try:
-                kubernetes.config.load_incluster_config()
-                config = kubernetes.client.Configuration.get_default_copy()
-                client = kubernetes.client.ApiClient(configuration=config)
-            except kubernetes.config.ConfigException:
-                client = kubernetes.config.new_client_from_config()
 
-        if os.environ.get(
-            "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", "TRUE"
-        ).strip().lower() in ("true", "1"):
-            enable_socket_keep_alive(client)
-
-        return client
+        return _get_cached_kubernetes_client(cluster_config)
 
     def _replace_api_key_with_secret(
         self, configuration: KubernetesWorkerJobConfiguration, client: "ApiClient"

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -175,7 +175,7 @@ class HashableKubernetesClusterConfig(BaseModel):
     Used for caching.
     """
 
-    config: Optional[dict[str, Any]] = Field(...)
+    config: Optional[dict] = Field(...)
     context_name: str = Field(...)
 
     def __hash__(self):

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -193,7 +193,7 @@ class HashableKubernetesClusterConfig(BaseModel):
 
 
 @lru_cache(maxsize=8, typed=True)
-def _get_cached_kubernetes_client(
+def _get_configured_kubernetes_client_cached(
     cluster_config: Optional[HashableKubernetesClusterConfig] = None,
 ) -> Any:
     "Returns a new Kubernetes client is there is not one cached"
@@ -758,7 +758,7 @@ class KubernetesWorker(BaseWorker):
                 context_name=configuration.cluster_config.context_name,
             )
 
-        return _get_cached_kubernetes_client(cluster_config)
+        return _get_configured_kubernetes_client_cached(cluster_config)
 
     def _replace_api_key_with_secret(
         self, configuration: KubernetesWorkerJobConfiguration, client: "ApiClient"

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -127,6 +127,7 @@ from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
+from prefect.utilities.hashing import hash_objects
 from prefect.utilities.importtools import lazy_import
 from prefect.utilities.pydantic import JsonPatch
 from prefect.utilities.templating import find_placeholders
@@ -152,7 +153,6 @@ from prefect_kubernetes.utilities import (
     _slugify_label_value,
     _slugify_name,
     enable_socket_keep_alive,
-    hash_collection,
 )
 
 if TYPE_CHECKING:
@@ -186,7 +186,7 @@ class HashableKubernetesClusterConfig(BaseModel):
         """Make the conifg hashable."""
         return hash(
             (
-                hash_collection(self.config),
+                hash_objects(self.config),
                 self.context_name,
             )
         )

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -196,7 +196,7 @@ class HashableKubernetesClusterConfig(BaseModel):
 def _get_configured_kubernetes_client_cached(
     cluster_config: Optional[HashableKubernetesClusterConfig] = None,
 ) -> Any:
-    "Returns a new Kubernetes client if there is not one cached"
+    """Returns a configured Kubernetes client."""
     with _LOCK:
         # if a hard-coded cluster config is provided, use it
         if cluster_config:

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -196,7 +196,7 @@ class HashableKubernetesClusterConfig(BaseModel):
 def _get_configured_kubernetes_client_cached(
     cluster_config: Optional[HashableKubernetesClusterConfig] = None,
 ) -> Any:
-    "Returns a new Kubernetes client is there is not one cached"
+    "Returns a new Kubernetes client if there is not one cached"
     with _LOCK:
         # if a hard-coded cluster config is provided, use it
         if cluster_config:

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -175,8 +175,12 @@ class HashableKubernetesClusterConfig(BaseModel):
     Used for caching.
     """
 
-    config: Optional[dict] = Field(...)
-    context_name: str = Field(...)
+    config: dict = Field(
+        default=..., description="The entire contents of a kubectl config file."
+    )
+    context_name: str = Field(
+        default=..., description="The name of the kubectl context to use."
+    )
 
     def __hash__(self):
         """Make the conifg hashable."""

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,7 +8,6 @@ from prefect.infrastructure.kubernetes import KubernetesJob
 from prefect_kubernetes.utilities import (
     convert_manifest_to_model,
     enable_socket_keep_alive,
-    hash_collection,
 )
 
 FAKE_CLUSTER = "fake-cluster"
@@ -239,34 +238,3 @@ def test_keep_alive_updates_socket_options(mock_api_client):
         ]._mock_set_call
         is not None
     )
-
-
-class TestHashCollection:
-    def test_simple_dict(self):
-        simple_dict = {"key1": "value1", "key2": "value2"}
-        assert hash_collection(simple_dict) == hash_collection(
-            simple_dict
-        ), "Simple dictionary hashing failed"
-
-    def test_nested_dict(self):
-        nested_dict = {"key1": {"subkey1": "subvalue1"}, "key2": "value2"}
-        assert hash_collection(nested_dict) == hash_collection(
-            nested_dict
-        ), "Nested dictionary hashing failed"
-
-    def test_complex_structure(self):
-        complex_structure = {
-            "key1": [1, 2, 3],
-            "key2": {"subkey1": {"subsubkey1": "value"}},
-        }
-        assert hash_collection(complex_structure) == hash_collection(
-            complex_structure
-        ), "Complex structure hashing failed"
-
-    def test_unhashable_structure(self):
-        typically_unhashable_structure = dict(key=dict(subkey=[1, 2, 3]))
-        with pytest.raises(TypeError):
-            hash(typically_unhashable_structure)
-        assert hash_collection(typically_unhashable_structure) == hash_collection(
-            typically_unhashable_structure
-        ), "Unhashable structure hashing failed after transformation"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,6 +8,7 @@ from prefect.infrastructure.kubernetes import KubernetesJob
 from prefect_kubernetes.utilities import (
     convert_manifest_to_model,
     enable_socket_keep_alive,
+    hash_collection,
 )
 
 FAKE_CLUSTER = "fake-cluster"
@@ -238,3 +239,34 @@ def test_keep_alive_updates_socket_options(mock_api_client):
         ]._mock_set_call
         is not None
     )
+
+
+class TestHashCollection:
+    def test_simple_dict(self):
+        simple_dict = {"key1": "value1", "key2": "value2"}
+        assert hash_collection(simple_dict) == hash_collection(
+            simple_dict
+        ), "Simple dictionary hashing failed"
+
+    def test_nested_dict(self):
+        nested_dict = {"key1": {"subkey1": "subvalue1"}, "key2": "value2"}
+        assert hash_collection(nested_dict) == hash_collection(
+            nested_dict
+        ), "Nested dictionary hashing failed"
+
+    def test_complex_structure(self):
+        complex_structure = {
+            "key1": [1, 2, 3],
+            "key2": {"subkey1": {"subsubkey1": "value"}},
+        }
+        assert hash_collection(complex_structure) == hash_collection(
+            complex_structure
+        ), "Complex structure hashing failed"
+
+    def test_unhashable_structure(self):
+        typically_unhashable_structure = dict(key=dict(subkey=[1, 2, 3]))
+        with pytest.raises(TypeError):
+            hash(typically_unhashable_structure)
+        assert hash_collection(typically_unhashable_structure) == hash_collection(
+            typically_unhashable_structure
+        ), "Unhashable structure hashing failed after transformation"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -49,7 +49,7 @@ from prefect_kubernetes import KubernetesWorker
 from prefect_kubernetes.utilities import _slugify_label_value, _slugify_name
 from prefect_kubernetes.worker import (
     KubernetesWorkerJobConfiguration,
-    _get_cached_kubernetes_client,
+    _get_configured_kubernetes_client_cached,
 )
 
 FAKE_CLUSTER = "fake-cluster"
@@ -1981,7 +1981,7 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        _get_cached_kubernetes_client.cache_clear()
+        _get_configured_kubernetes_client_cached.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -1999,7 +1999,7 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        _get_cached_kubernetes_client.cache_clear()
+        _get_configured_kubernetes_client_cached.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
         mock_cluster_config.load_incluster_config.side_effect = ConfigException()
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -2016,18 +2016,18 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        _get_cached_kubernetes_client.cache_clear()
+        _get_configured_kubernetes_client_cached.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
-        assert _get_cached_kubernetes_client.cache_info().hits == 0
+        assert _get_configured_kubernetes_client_cached.cache_info().hits == 0
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
             await k8s_worker.run(flow_run, default_configuration)
             await k8s_worker.run(flow_run, default_configuration)
 
-        assert _get_cached_kubernetes_client.cache_info().misses == 1
-        assert _get_cached_kubernetes_client.cache_info().hits == 2
+        assert _get_configured_kubernetes_client_cached.cache_info().misses == 1
+        assert _get_configured_kubernetes_client_cached.cache_info().hits == 2
 
     @pytest.mark.parametrize("job_timeout", [24, 100])
     async def test_allows_configurable_timeouts_for_pod_and_job_watches(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -47,7 +47,10 @@ else:
 
 from prefect_kubernetes import KubernetesWorker
 from prefect_kubernetes.utilities import _slugify_label_value, _slugify_name
-from prefect_kubernetes.worker import KubernetesWorkerJobConfiguration
+from prefect_kubernetes.worker import (
+    KubernetesWorkerJobConfiguration,
+    _get_cached_kubernetes_client,
+)
 
 FAKE_CLUSTER = "fake-cluster"
 MOCK_CLUSTER_UID = "1234"
@@ -1978,6 +1981,7 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
+        _get_cached_kubernetes_client.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -1995,6 +1999,7 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
+        _get_cached_kubernetes_client.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
         mock_cluster_config.load_incluster_config.side_effect = ConfigException()
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2007,6 +2007,28 @@ class TestKubernetesWorker:
 
             mock_cluster_config.new_client_from_config.assert_called_once()
 
+    async def test_get_configured_kubernetes_client_cached(
+        self,
+        flow_run,
+        default_configuration,
+        mock_core_client,
+        mock_watch,
+        mock_cluster_config,
+        mock_batch_client,
+    ):
+        _get_cached_kubernetes_client.cache_clear()
+        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
+
+        assert _get_cached_kubernetes_client.cache_info().hits == 0
+
+        async with KubernetesWorker(work_pool_name="test") as k8s_worker:
+            await k8s_worker.run(flow_run, default_configuration)
+            await k8s_worker.run(flow_run, default_configuration)
+            await k8s_worker.run(flow_run, default_configuration)
+
+        assert _get_cached_kubernetes_client.cache_info().misses == 1
+        assert _get_cached_kubernetes_client.cache_info().hits == 2
+
     @pytest.mark.parametrize("job_timeout", [24, 100])
     async def test_allows_configurable_timeouts_for_pod_and_job_watches(
         self,


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #102 

Uses cached Kubernetes `ApiClient`s to prevent the buildup of open sockets. Previously, one socket per flow run would remain in a `CLOSE_WAIT` state.


### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

**Tracking open sockets**
Before:
```bash
~$ cat /proc/net/tcp | wc -l
4
```
Run a deployment 5 times:
```bash
~$ cat /proc/net/tcp | wc -l
9
```
Run a deployment 4 more times:
```bash
~$ cat /proc/net/tcp | wc -l
13
```

After:
```bash
~$ cat /proc/net/tcp | wc -l
4
```
Run a deployment 5 times:
```bash
~$ cat /proc/net/tcp | wc -l
4
```
Run a deployment 4 more times:
```bash
~$ cat /proc/net/tcp | wc -l
4
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/CHANGELOG.md)
