### PR TITLE
Add tenacity retries to run method

### DIFF
--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -145,6 +145,7 @@ if PYDANTIC_VERSION.startswith("2."):
 else:
     from pydantic import Field, validator
 
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 from typing_extensions import Literal
 
 from prefect_kubernetes.events import KubernetesEventsReplicator
@@ -154,7 +155,6 @@ from prefect_kubernetes.utilities import (
     _slugify_name,
     enable_socket_keep_alive,
 )
-from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 if TYPE_CHECKING:
     import kubernetes
@@ -802,9 +802,9 @@ class KubernetesWorker(BaseWorker):
             )
             # Store configuration so that we can delete the secret when the worker shuts
             # down
-            self._created_secrets[(secret.metadata.name, secret.metadata.namespace)] = (
-                configuration
-            )
+            self._created_secrets[
+                (secret.metadata.name, secret.metadata.namespace)
+            ] = configuration
             new_api_env_entry = {
                 "name": "PREFECT_API_KEY",
                 "valueFrom": {"secretKeyRef": {"name": secret_name, "key": "value"}},

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -610,15 +610,6 @@ class KubernetesWorker(BaseWorker):
         super().__init__(*args, **kwargs)
         self._created_secrets = {}
 
-    @retry(
-        stop=stop_after_attempt(MAX_ATTEMPTS),
-        wait=wait_fixed(RETRY_MIN_DELAY_SECONDS)
-        + wait_random(
-            RETRY_MIN_DELAY_JITTER_SECONDS,
-            RETRY_MAX_DELAY_JITTER_SECONDS,
-        ),
-        reraise=True,
-    )
     async def run(
         self,
         flow_run: "FlowRun",
@@ -817,6 +808,15 @@ class KubernetesWorker(BaseWorker):
                 "env"
             ] = manifest_env
 
+    @retry(
+        stop=stop_after_attempt(MAX_ATTEMPTS),
+        wait=wait_fixed(RETRY_MIN_DELAY_SECONDS)
+        + wait_random(
+            RETRY_MIN_DELAY_JITTER_SECONDS,
+            RETRY_MAX_DELAY_JITTER_SECONDS,
+        ),
+        reraise=True,
+    )
     def _create_job(
         self, configuration: KubernetesWorkerJobConfiguration, client: "ApiClient"
     ) -> "V1Job":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prefect>=2.13.5
 kubernetes >= 24.2.0
+tenacity >= 8.2.3


### PR DESCRIPTION
In order to support a greater degree of resiliency in job creation we're adding tenacity to preserve existing signatures and provide retry functionality. 

Closes #116

### Example
    @retry(
        stop=stop_after_attempt(MAX_ATTEMPTS),
        wait=wait_fixed(RETRY_MIN_DELAY_SECONDS)
        + wait_random(
            RETRY_MIN_DELAY_JITTER_SECONDS,
            RETRY_MAX_DELAY_JITTER_SECONDS,
        ),
        reraise=True,
    )
### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
