### PR TITLE
Handle 410s during Job watch

### DIFF
--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -966,7 +966,6 @@ class KubernetesWorker(BaseWorker):
 
         See https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes  # noqa
         """
-        print("watching")
         while True:
             try:
 
@@ -981,9 +980,7 @@ class KubernetesWorker(BaseWorker):
                     job_list = batch_client.list_namespaced_job(
                         namespace=namespace, field_selector=f"metadata.name={job_name}"
                     )
-                    print(job_list)
                     resource_version = job_list.metadata.resource_version
-                    print(f"got rv {resource_version}")
                     watch_kwargs["resource_version"] = resource_version
                 else:
                     raise

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -112,7 +112,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple, Union
 
 import anyio.abc
 from kubernetes.client.exceptions import ApiException
@@ -957,7 +957,7 @@ class KubernetesWorker(BaseWorker):
         job_name: str,
         namespace: str,
         watch_kwargs: dict,
-    ) -> Generator[Any | dict | str, Any, None]:
+    ) -> Generator[Union[Any, dict, str], Any, None]:
         """
         Stream job events.
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -957,7 +957,7 @@ class KubernetesWorker(BaseWorker):
         job_name: str,
         namespace: str,
         watch_kwargs: dict,
-    ):
+    ) -> Generator[Any | dict | str, Any, None]:
         """
         Stream job events.
 

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -966,8 +966,10 @@ class KubernetesWorker(BaseWorker):
 
         See https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes  # noqa
         """
+        print("watching")
         while True:
             try:
+
                 return watch.stream(
                     func=batch_client.list_namespaced_job,
                     namespace=namespace,
@@ -976,8 +978,12 @@ class KubernetesWorker(BaseWorker):
                 )
             except ApiException as e:
                 if e.status == 410:
-                    job = batch_client.list_namespaced_job(namespace=namespace)
-                    resource_version = job.metadata.resource_version
+                    job_list = batch_client.list_namespaced_job(
+                        namespace=namespace, field_selector=f"metadata.name={job_name}"
+                    )
+                    print(job_list)
+                    resource_version = job_list.metadata.resource_version
+                    print(f"got rv {resource_version}")
                     watch_kwargs["resource_version"] = resource_version
                 else:
                     raise

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -975,7 +975,7 @@ class KubernetesWorker(BaseWorker):
                     **watch_kwargs,
                 )
             except ApiException as e:
-                if str(e.status) == "410":
+                if e.status == 410:
                     job = batch_client.list_namespaced_job(namespace=namespace)
                     resource_version = job.metadata.resource_version
                     watch_kwargs["resource_version"] = resource_version

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -968,7 +968,6 @@ class KubernetesWorker(BaseWorker):
         """
         while True:
             try:
-
                 return watch.stream(
                     func=batch_client.list_namespaced_job,
                     namespace=namespace,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -157,22 +157,6 @@ def _mock_pods_stream_that_returns_running_pod(*args, **kwargs):
     ]
 
 
-def _mock_stream_that_raises_410_if_job(*args, **kwargs):
-    job_pod = MagicMock(spec=kubernetes.client.V1Pod)
-    job_pod.status.phase = "Running"
-
-    job = MagicMock(spec=kubernetes.client.V1Job)
-    job.status.completion_time = pendulum.now("utc").timestamp()
-
-    if kwargs["func"] == kubernetes.client.BatchV1Api.list_namespaced_job:
-        raise ApiException(status=410, reason="Gone")
-
-    return [
-        {"object": job_pod, "type": "MODIFIED"},
-        {"object": job, "type": "MODIFIED"},
-    ]
-
-
 @pytest.fixture
 def enable_store_api_key_in_secret(monkeypatch):
     monkeypatch.setenv("PREFECT_KUBERNETES_WORKER_STORE_PREFECT_API_IN_SECRET", "true")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2637,12 +2637,10 @@ class TestKubernetesWorker:
             _mock_pods_stream_that_returns_running_pod(),
         ]
 
-        job_list_1 = MagicMock(spec=kubernetes.client.V1JobList)
-        job_list_1.metadata.resource_version = "1"
+        job_list = MagicMock(spec=kubernetes.client.V1JobList)
+        job_list.metadata.resource_version = "1"
 
-        mock_batch_client.list_namespaced_job.side_effect = [
-            job_list_1,
-        ]
+        mock_batch_client.list_namespaced_job.side_effect = [job_list]
 
         # The job should not be completed to start
         mock_batch_client.read_namespaced_job.return_value.status.completion_time = None


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect/issues/8573

410 errors are seen from the Kubernetes API when the `resourceVersion` of a resource that's being `watch`ed no longer exists. Though a `watch` is meant to keep up with `resourceVersion` changes, it is possible to get out of sync due to network fragility or server-side timeouts on long-running HTTP connections, especially because historical `resourceVersion`s are not maintained after a default of 5 minutes in most cases.

410s are hard to induce manually but are reported at a regular pace by Prefect users. I have also encountered them myself. The recommended practice is to [list-then-watch](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) after a 410, so that's what this implementation does. Trying to re-list a job that was the source of a 410 but can no longer be watched should at the very least raise a more informative error if it for some reason failed or no longer exists.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
