### PR TITLE
Release sockets without caching

### DIFF
--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -110,8 +110,6 @@ import shlex
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from functools import lru_cache
-from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple, Union
 
 import anyio.abc
@@ -127,7 +125,6 @@ from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
-from prefect.utilities.hashing import hash_objects
 from prefect.utilities.importtools import lazy_import
 from prefect.utilities.pydantic import JsonPatch
 from prefect.utilities.templating import find_placeholders
@@ -138,7 +135,6 @@ from prefect.workers.base import (
     BaseWorkerResult,
 )
 from pydantic import VERSION as PYDANTIC_VERSION
-from pydantic import BaseModel
 
 if PYDANTIC_VERSION.startswith("2."):
     from pydantic.v1 import Field, validator
@@ -171,64 +167,6 @@ MAX_ATTEMPTS = 3
 RETRY_MIN_DELAY_SECONDS = 1
 RETRY_MIN_DELAY_JITTER_SECONDS = 0
 RETRY_MAX_DELAY_JITTER_SECONDS = 3
-
-
-_LOCK = Lock()
-
-
-class HashableKubernetesClusterConfig(BaseModel):
-    """
-    A hashable version of the KubernetesClusterConfig class.
-    Used for caching.
-    """
-
-    config: dict = Field(
-        default=..., description="The entire contents of a kubectl config file."
-    )
-    context_name: str = Field(
-        default=..., description="The name of the kubectl context to use."
-    )
-
-    def __hash__(self):
-        """Make the conifg hashable."""
-        return hash(
-            (
-                hash_objects(self.config),
-                self.context_name,
-            )
-        )
-
-
-@lru_cache(maxsize=8, typed=True)
-def _get_configured_kubernetes_client_cached(
-    cluster_config: Optional[HashableKubernetesClusterConfig] = None,
-) -> Any:
-    """Returns a configured Kubernetes client."""
-    with _LOCK:
-        # if a hard-coded cluster config is provided, use it
-        if cluster_config:
-            client = kubernetes.config.new_client_from_config_dict(
-                config_dict=cluster_config.config,
-                context=cluster_config.context_name,
-            )
-        else:
-            # If no hard-coded config specified, try to load Kubernetes configuration
-            # within a cluster. If that doesn't work, try to load the configuration
-            # from the local environment, allowing any further ConfigExceptions to
-            # bubble up.
-            try:
-                kubernetes.config.load_incluster_config()
-                config = kubernetes.client.Configuration.get_default_copy()
-                client = kubernetes.client.ApiClient(configuration=config)
-            except kubernetes.config.ConfigException:
-                client = kubernetes.config.new_client_from_config()
-
-        if os.environ.get(
-            "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", "TRUE"
-        ).strip().lower() in ("true", "1"):
-            enable_socket_keep_alive(client)
-
-        return client
 
 
 def _get_default_job_manifest_template() -> Dict[str, Any]:
@@ -750,22 +688,40 @@ class KubernetesWorker(BaseWorker):
                 else:
                     raise
 
+    @contextmanager
     def _get_configured_kubernetes_client(
         self, configuration: KubernetesWorkerJobConfiguration
-    ) -> "ApiClient":
+    ) -> Generator["ApiClient", None, None]:
         """
         Returns a configured Kubernetes client.
         """
 
-        cluster_config = None
+        try:
+            if configuration.cluster_config:
+                client = kubernetes.config.new_client_from_config_dict(
+                    config_dict=configuration.cluster_config.config,
+                    context=configuration.cluster_config.context_name,
+                )
+            else:
+                # If no hardcoded config specified, try to load Kubernetes configuration
+                # within a cluster. If that doesn't work, try to load the configuration
+                # from the local environment, allowing any further ConfigExceptions to
+                # bubble up.
+                try:
+                    kubernetes.config.load_incluster_config()
+                    config = kubernetes.client.Configuration.get_default_copy()
+                    client = kubernetes.client.ApiClient(configuration=config)
+                except kubernetes.config.ConfigException:
+                    client = kubernetes.config.new_client_from_config()
 
-        if configuration.cluster_config:
-            cluster_config = HashableKubernetesClusterConfig(
-                config=configuration.cluster_config.config,
-                context_name=configuration.cluster_config.context_name,
-            )
+            if os.environ.get(
+                "PREFECT_KUBERNETES_WORKER_ADD_TCP_KEEPALIVE", "TRUE"
+            ).strip().lower() in ("true", "1"):
+                enable_socket_keep_alive(client)
 
-        return _get_configured_kubernetes_client_cached(cluster_config)
+            yield client
+        finally:
+            client.rest_client.pool_manager.clear()
 
     def _replace_api_key_with_secret(
         self, configuration: KubernetesWorkerJobConfiguration, client: "ApiClient"

--- a/prefect_kubernetes/worker.py
+++ b/prefect_kubernetes/worker.py
@@ -648,45 +648,45 @@ class KubernetesWorker(BaseWorker):
         grace_seconds: int = 30,
     ):
         """Removes the given Job from the Kubernetes cluster"""
-        client = self._get_configured_kubernetes_client(configuration)
-        job_cluster_uid, job_namespace, job_name = self._parse_infrastructure_pid(
-            infrastructure_pid
-        )
-
-        if job_namespace != configuration.namespace:
-            raise InfrastructureNotAvailable(
-                f"Unable to kill job {job_name!r}: The job is running in namespace "
-                f"{job_namespace!r} but this worker expected jobs to be running in "
-                f"namespace {configuration.namespace!r} based on the work pool and "
-                "deployment configuration."
+        with self._get_configured_kubernetes_client(configuration) as client:
+            job_cluster_uid, job_namespace, job_name = self._parse_infrastructure_pid(
+                infrastructure_pid
             )
 
-        current_cluster_uid = self._get_cluster_uid(client)
-        if job_cluster_uid != current_cluster_uid:
-            raise InfrastructureNotAvailable(
-                f"Unable to kill job {job_name!r}: The job is running on another "
-                "cluster than the one specified by the infrastructure PID."
-            )
-
-        with self._get_batch_client(client) as batch_client:
-            try:
-                batch_client.delete_namespaced_job(
-                    name=job_name,
-                    namespace=job_namespace,
-                    grace_period_seconds=grace_seconds,
-                    # Foreground propagation deletes dependent objects before deleting
-                    # owner objects. This ensures that the pods are cleaned up before
-                    # the job is marked as deleted.
-                    # See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion # noqa
-                    propagation_policy="Foreground",
+            if job_namespace != configuration.namespace:
+                raise InfrastructureNotAvailable(
+                    f"Unable to kill job {job_name!r}: The job is running in namespace "
+                    f"{job_namespace!r} but this worker expected jobs to be running in "
+                    f"namespace {configuration.namespace!r} based on the work pool and "
+                    "deployment configuration."
                 )
-            except kubernetes.client.exceptions.ApiException as exc:
-                if exc.status == 404:
-                    raise InfrastructureNotFound(
-                        f"Unable to kill job {job_name!r}: The job was not found."
-                    ) from exc
-                else:
-                    raise
+
+            current_cluster_uid = self._get_cluster_uid(client)
+            if job_cluster_uid != current_cluster_uid:
+                raise InfrastructureNotAvailable(
+                    f"Unable to kill job {job_name!r}: The job is running on another "
+                    "cluster than the one specified by the infrastructure PID."
+                )
+
+            with self._get_batch_client(client) as batch_client:
+                try:
+                    batch_client.delete_namespaced_job(
+                        name=job_name,
+                        namespace=job_namespace,
+                        grace_period_seconds=grace_seconds,
+                        # Foreground propagation deletes dependent objects before deleting # noqa
+                        # owner objects. This ensures that the pods are cleaned up before # noqa
+                        # the job is marked as deleted.
+                        # See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion # noqa
+                        propagation_policy="Foreground",
+                    )
+                except kubernetes.client.exceptions.ApiException as exc:
+                    if exc.status == 404:
+                        raise InfrastructureNotFound(
+                            f"Unable to kill job {job_name!r}: The job was not found."
+                        ) from exc
+                    else:
+                        raise
 
     @contextmanager
     def _get_configured_kubernetes_client(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -47,10 +47,7 @@ else:
 
 from prefect_kubernetes import KubernetesWorker
 from prefect_kubernetes.utilities import _slugify_label_value, _slugify_name
-from prefect_kubernetes.worker import (
-    KubernetesWorkerJobConfiguration,
-    _get_configured_kubernetes_client_cached,
-)
+from prefect_kubernetes.worker import KubernetesWorkerJobConfiguration
 
 FAKE_CLUSTER = "fake-cluster"
 MOCK_CLUSTER_UID = "1234"
@@ -2024,7 +2021,6 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        _get_configured_kubernetes_client_cached.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
 
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -2042,35 +2038,12 @@ class TestKubernetesWorker:
         mock_cluster_config,
         mock_batch_client,
     ):
-        _get_configured_kubernetes_client_cached.cache_clear()
         mock_watch.stream = _mock_pods_stream_that_returns_running_pod
         mock_cluster_config.load_incluster_config.side_effect = ConfigException()
         async with KubernetesWorker(work_pool_name="test") as k8s_worker:
             await k8s_worker.run(flow_run, default_configuration)
 
             mock_cluster_config.new_client_from_config.assert_called_once()
-
-    async def test_get_configured_kubernetes_client_cached(
-        self,
-        flow_run,
-        default_configuration,
-        mock_core_client,
-        mock_watch,
-        mock_cluster_config,
-        mock_batch_client,
-    ):
-        _get_configured_kubernetes_client_cached.cache_clear()
-        mock_watch.stream = _mock_pods_stream_that_returns_running_pod
-
-        assert _get_configured_kubernetes_client_cached.cache_info().hits == 0
-
-        async with KubernetesWorker(work_pool_name="test") as k8s_worker:
-            await k8s_worker.run(flow_run, default_configuration)
-            await k8s_worker.run(flow_run, default_configuration)
-            await k8s_worker.run(flow_run, default_configuration)
-
-        assert _get_configured_kubernetes_client_cached.cache_info().misses == 1
-        assert _get_configured_kubernetes_client_cached.cache_info().hits == 2
 
     @pytest.mark.parametrize("job_timeout", [24, 100])
     async def test_allows_configurable_timeouts_for_pod_and_job_watches(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

The [previous solution](https://github.com/PrefectHQ/prefect-kubernetes/pull/111) to the socket accumulation [issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/102) was overcomplicated and introduced caching when it wasn't necessary.

Instead, we can clear the `pool_manager` the same way we do for the other k8s client types.

The same test as the previous fix was conducted, and the same results were observed, with the occupied socket count on the worker pod returning to 4 after all flow runs completed.

```
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
7
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
15
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
17
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
17
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
17
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
17
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
18
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
17
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
16
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
18
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
19
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
20
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
17
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
18
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
10
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
10
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
9
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
9
root@prefect-worker-7cc77cd984-88pvp:~# cat /proc/net/tcp | wc -l
4
```

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-kubernetes/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
